### PR TITLE
Split generated from source code files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: make protoc
         run: make PROTOC_BIN=./bin/protoc all
       - name: Publish to GitHub Packages
-        run: ./gradlew clean publish
+        run: ./gradlew clean build publish
         working-directory: java
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ node/v1
 bin/protoc
 java/build
 java/.gradle
-java/src/main/java/de/stroeer/api/v1
+java/src/main/gen
 .gradle
 *.iml
 *.ipr

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 .PHONY: clean dir help java node
 all: clean java node
 
-JAVA_DIR = ./java/src/main/java
+JAVA_DIR = ./java/src/main/gen
 PROTO_DIR = ./api
 NODE_DIR = ./node
 PROTOC_BIN ?= protoc

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -42,6 +42,7 @@ sourceSets {
     main {
         java {
             srcDirs 'src/main/java'
+            srcDirs 'src/main/gen'
         }
     }
     test {

--- a/java/src/main/java/de/stroeer/api/config/ProtobufSerializer.java
+++ b/java/src/main/java/de/stroeer/api/config/ProtobufSerializer.java
@@ -9,11 +9,11 @@ import com.google.protobuf.util.JsonFormat;
 import java.io.IOException;
 
 // borrowed from https://github.com/venth/training-webflux-grpc
-class ProtobufSerializer extends StdSerializer<GeneratedMessageV3> {
+public class ProtobufSerializer extends StdSerializer<GeneratedMessageV3> {
 
   private final JsonFormat.Printer printer;
 
-  ProtobufSerializer() {
+  public ProtobufSerializer() {
     super(GeneratedMessageV3.class);
     printer = JsonFormat.printer()
         .preservingProtoFieldNames()

--- a/java/src/test/de/stroeer/v1/article/ArticleTest.java
+++ b/java/src/test/de/stroeer/v1/article/ArticleTest.java
@@ -1,8 +1,14 @@
 package de.stroeer.v1.article;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import de.stroeer.api.v1.article.Article;
 import de.stroeer.api.v1.article.Article.Builder;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
+import de.stroeer.api.config.*;
+
 
 class ArticleTest {
 
@@ -12,5 +18,18 @@ class ArticleTest {
     articleBuilder.setId("id");
     de.stroeer.api.v1.article.Article article = articleBuilder.build();
     assertEquals(article.getId(), "id");
+  }
+
+  @Test
+  void ProtoSerializerIsBundled() throws JsonProcessingException {
+    ObjectMapper mapper = new ObjectMapper();
+    SimpleModule module = new SimpleModule();
+    module.addSerializer(Article.class, new ProtobufSerializer());
+    mapper.registerModule(module);
+    Builder articleBuilder = de.stroeer.api.v1.article.Article.newBuilder();
+    articleBuilder.setId("id");
+    de.stroeer.api.v1.article.Article article = articleBuilder.build();
+    String s = mapper.writeValueAsString(article);
+    assertNotNull(s);
   }
 }


### PR DESCRIPTION
WHY:
`make clean` deleted source code that should have been bundled in the jar