### PR TITLE
Draft for self contained body

### DIFF
--- a/stroeer/core/v1/article.proto
+++ b/stroeer/core/v1/article.proto
@@ -53,14 +53,14 @@ message Author {
 }
 
 message Body {
-  repeated HtmlNode children = 1;
+  repeated BodyNode children = 1;
 }
 
-message HtmlNode {
-  HtmlNodeType type = 1;
+message BodyNode {
+  string type = 1;
   string text = 2;
   map<string, string> fields = 3;
-  repeated HtmlNode children = 4;
+  repeated BodyNode children = 4;
   repeated Element elements = 5; // inline-video, content|rich-links, gallery
 }
 
@@ -88,14 +88,4 @@ enum AssetType {
   ASSET_TYPE_VIDEO = 2;
   ASSET_TYPE_URL = 3;
   ASSET_TYPE_METADATA = 4;
-}
-
-enum HtmlNodeType {
-  HTML_NODE_TYPE_UNSPECIFIED = 0;
-  HTML_NODE_TYPE_PARAGRAPH = 1;
-  HTML_NODE_TYPE_SUB = 2;
-  HTML_NODE_TYPE_SUP = 3;
-  HTML_NODE_TYPE_ANCHOR = 4;
-  HTML_NODE_TYPE_UNORDERED_LIST = 5;
-  HTML_NODE_TYPE_LIST_ITEM = 6;
 }

--- a/stroeer/core/v1/article.proto
+++ b/stroeer/core/v1/article.proto
@@ -21,7 +21,7 @@ message Article {
   repeated Element elements = 10;
   repeated Author authors = 11;
   repeated string onwards = 12;
-  repeated Body body = 13;
+  Body body = 13;
 }
 
 message Metadata {

--- a/stroeer/core/v1/article.proto
+++ b/stroeer/core/v1/article.proto
@@ -21,6 +21,7 @@ message Article {
   repeated Element elements = 10;
   repeated Author authors = 11;
   repeated string onwards = 12;
+  repeated Body body = 13;
 }
 
 message Metadata {
@@ -51,6 +52,18 @@ message Author {
   string web_url = 3;
 }
 
+message Body {
+  repeated HtmlNode children = 1;
+}
+
+message HtmlNode {
+  HtmlNodeType type = 1;
+  string text = 2;
+  map<string, string> fields = 3;
+  repeated HtmlNode children = 4;
+  repeated Element elements = 5; // inline-video, content|rich-links, gallery
+}
+
 enum ContentType {
   CONTENT_TYPE_UNSPECIFIED = 0;
   CONTENT_TYPE_ARTICLE = 1;
@@ -75,4 +88,14 @@ enum AssetType {
   ASSET_TYPE_VIDEO = 2;
   ASSET_TYPE_URL = 3;
   ASSET_TYPE_METADATA = 4;
+}
+
+enum HtmlNodeType {
+  HTML_NODE_TYPE_UNSPECIFIED = 0;
+  HTML_NODE_TYPE_PARAGRAPH = 1;
+  HTML_NODE_TYPE_SUB = 2;
+  HTML_NODE_TYPE_SUP = 3;
+  HTML_NODE_TYPE_ANCHOR = 4;
+  HTML_NODE_TYPE_UNORDERED_LIST = 5;
+  HTML_NODE_TYPE_LIST_ITEM = 6;
 }

--- a/stroeer/web/article/v1/web_article.proto
+++ b/stroeer/web/article/v1/web_article.proto
@@ -18,6 +18,7 @@ message WebArticle {
   map<string, string> fields = 7;
   repeated stroeer.core.v1.Element elements = 8;
   repeated stroeer.core.v1.Author authors = 9;
+  repeated stroeer.core.v1.Body body = 10;
 }
 
 message RelatedWebArticle {

--- a/stroeer/web/article/v1/web_article.proto
+++ b/stroeer/web/article/v1/web_article.proto
@@ -18,7 +18,6 @@ message WebArticle {
   map<string, string> fields = 7;
   repeated stroeer.core.v1.Element elements = 8;
   repeated stroeer.core.v1.Author authors = 9;
-  repeated stroeer.core.v1.Body body = 10;
 }
 
 message RelatedWebArticle {

--- a/stroeer/web/article/v1/web_article.proto
+++ b/stroeer/web/article/v1/web_article.proto
@@ -18,6 +18,7 @@ message WebArticle {
   map<string, string> fields = 7;
   repeated stroeer.core.v1.Element elements = 8;
   repeated stroeer.core.v1.Author authors = 9;
+  repeated stroeer.core.v1.BodyNode body_nodes = 10;
 }
 
 message RelatedWebArticle {

--- a/stroeer/web/article/v1/web_article_service.proto
+++ b/stroeer/web/article/v1/web_article_service.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package stroeer.web.article.v1;
 
+import "stroeer/core/v1/article.proto";
 import "stroeer/web/article/v1/web_article.proto";
 
 option go_package = "github.com/stroeer/tapir/go/stroeer/web/article/v1;article";
@@ -17,10 +18,13 @@ service WebArticleService {
 
 message GetWebArticlePageRequest {
   string id = 1;
+  string page = 2;
 }
 
 message GetWebArticlePageResponse {
   WebArticle web_article = 1;
   repeated RelatedWebArticle related_web_articles = 2;
+  repeated stroeer.core.v1.BodyNode body_nodes = 3;
+  int32 pages = 4;
 }
 

--- a/stroeer/web/article/v1/web_article_service.proto
+++ b/stroeer/web/article/v1/web_article_service.proto
@@ -18,12 +18,10 @@ service WebArticleService {
 
 message GetWebArticlePageRequest {
   string id = 1;
-  string page = 2;
 }
 
 message GetWebArticlePageResponse {
   WebArticle web_article = 1;
   repeated RelatedWebArticle related_web_articles = 2;
-  uint32 pages = 3;
 }
 

--- a/stroeer/web/article/v1/web_article_service.proto
+++ b/stroeer/web/article/v1/web_article_service.proto
@@ -25,6 +25,6 @@ message GetWebArticlePageResponse {
   WebArticle web_article = 1;
   repeated RelatedWebArticle related_web_articles = 2;
   repeated stroeer.core.v1.BodyNode body_nodes = 3;
-  int32 pages = 4;
+  uint32 pages = 4;
 }
 

--- a/stroeer/web/article/v1/web_article_service.proto
+++ b/stroeer/web/article/v1/web_article_service.proto
@@ -24,7 +24,6 @@ message GetWebArticlePageRequest {
 message GetWebArticlePageResponse {
   WebArticle web_article = 1;
   repeated RelatedWebArticle related_web_articles = 2;
-  repeated stroeer.core.v1.BodyNode body_nodes = 3;
-  uint32 pages = 4;
+  uint32 pages = 3;
 }
 


### PR DESCRIPTION
Another approach on stroeer/rfb#8

Concepts:

- body is self contained and there are no references outside its scope required to render it
- allow recursion (see example `ul>li`)
- we suggest embedding complex entities (inline-articles, inline-videos, inline-galleries, ...) as `elements` where the are required. Use this for teasers and rich `<a>` with "hover effect"
- the body is a `repeated` element which would allow splitting a long story or newsticker into multiple pages (`/$article/page-1`, `/$article/page-2`) to increase PIs and AIs (Martin likes the idea 🤑)
- since the body is self contained, it may be missing when the article is used as a "trail\"

Sample structure would look like this

```id: "$ARTICLE_ID"
   body {
     children {
       type: HTML_NODE_TYPE_PARAGRAPH
       text: "Hello, world! This is paragraph 1."
     }
     children {
       type: HTML_NODE_TYPE_PARAGRAPH
       text: "Hello, world! This is paragraph 2."
     }
     children {
       type: HTML_NODE_TYPE_PARAGRAPH
       text: "Hello, world! This is paragraph 3."
     }
     children {
       type: HTML_NODE_TYPE_PARAGRAPH
       text: "Hello, world! This is paragraph 4."
     }
     children {
       type: HTML_NODE_TYPE_ANCHOR
       text: "Webseite von example.com (\303\266ffnet extern)"
       fields {
         key: "href"
         value: "https://www.example.com"
       }
       fields {
         key: "target"
         value: "_blank"
       }
     }
     children {
       type: HTML_NODE_TYPE_UNORDERED_LIST
       children {
         type: HTML_NODE_TYPE_LIST_ITEM
         text: "list item #1"
       }
       children {
         type: HTML_NODE_TYPE_LIST_ITEM
         text: "list item #2"
       }
       children {
         type: HTML_NODE_TYPE_LIST_ITEM
         text: "list item #3"
       }
       children {
         type: HTML_NODE_TYPE_LIST_ITEM
         text: "list item #4"
       }
     }
   }```