### PR TITLE
feature / dependabot for docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "docker" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Enable dependabot to check whether our Docker image can be updated or not on a daily basis

- Support for docker -> [here](https://dependabot.com/docker/)
- Ecosystem found -> [here](https://docs.github.com/en/github/administering-a-repository/about-github-dependabot-version-updates#supported-repositories-and-ecosystems).