### PR TITLE
feature / GHCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ The **T**-online **API** **R**epository contains the interface definitions of t-
 
 T-online APIs use [Protocol Buffers](https://github.com/google/protobuf) version 3 (proto3) as their Interface Definition Language (IDL) to define the API interface and the structure of the payload messages.
 
-## building
+## Build
 
-We use [stroeer/protoc-dockerized](https://hub.docker.com/repository/docker/stroeer/protoc-dockerized) as `protoc` which currently supports generating code for
+We use [stroeer/protoc-dockerized](https://github.com/orgs/stroeer/packages/container/package/protoc-dockerized) as `protoc` which currently supports generating code for
 
 - `java`
 - `node/TypeScript`
@@ -70,16 +70,19 @@ $ make LANGUAGE=go
 Generating go code is currently not part of the release process. Go sources need
 to be generated locally and added to pull requests.
 
-### Docker Image for `stroeer/protoc-dockerized`
+## Docker Image for `stroeer/protoc-dockerized`
 
-#### Requirements
-- be member of https://hub.docker.com/u/stroeer
-- login to hub.docker.com with docker login
+### Requirements
 
-#### Release new version
+Login to `ghcr.io` with your Github user name and a Github personal access token having permissions to `read:packages`, `write:packages` and/or `delete:packages`:
+
+```sh
+cat ~/Token.txt | docker login -u USERNAME --password-stdin
+```
+
+### Release new version
+
 - look at Requirements above
 - bump versions in `build_docker.sh`
 - run `build_docker.sh`
-- run `docker push stroeer/protoc-dockerized:latest`
-
-
+- run `docker push ghcr.io/stroeer/protoc-dockerized:latest`

--- a/build_docker.sh
+++ b/build_docker.sh
@@ -1,4 +1,4 @@
-docker build -t stroeer/protoc-dockerized:latest \
+docker build -t ghcr.io/stroeer/protoc-dockerized:latest \
 --build-arg NODE_GRPC_TOOLS_VERSION="1.9.0" \
 --build-arg NODE_TS_PROTOC_GEN_VERSION="0.12.0" \
 --build-arg JAVA_LIB_VERSION="1.29.0" \


### PR DESCRIPTION
## What

Manually built and published docker image to Github Container Registry (GHCR).
Replaced docker hub urls with GHCR urls in build script.
Updated docs accordingly in `Readme.md`.

## How

feature: replaced Docker Hub image URL with Github Container Registry (GHCR) image url
refactor: added newline to end of Shell script to build docker image
docs: updated URL to Docker image
docs: updated requirements for docker image creation and release
