### PR TITLE
BUZZ-320: WebSectionPage API

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -10,5 +10,6 @@ lint:
     - RPC_RESPONSE_STANDARD_NAME
   ignore:
     - all-web.proto
+    - all-pages.proto
     - all-core.proto
     - all-coremedia.proto

--- a/stroeer/web/section/v1/web_section_page.proto
+++ b/stroeer/web/section/v1/web_section_page.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+
+package stroeer.web.section.v1;
+
+import "stroeer/web/article/v1/web_article.proto";
+
+option go_package = "github.com/stroeer/tapir/go/stroeer/web/section/v1;section";
+option java_multiple_files = true;
+option java_package = "de.stroeer.web.section.v1";
+
+message WebSectionPage {
+  repeated Stage stages = 1;
+}
+
+message Stage {
+  repeated stroeer.web.article.v1.WebArticle web_articles = 1;
+  StageConfiguration stage_configuration = 2;
+  repeated Stage stages = 3;
+}
+
+message StageConfiguration {
+  map<string, string> fields = 1;
+  string layout = 2;
+}

--- a/stroeer/web/section/v1/web_section_service.proto
+++ b/stroeer/web/section/v1/web_section_service.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package stroeer.web.section.v1;
 
-import "stroeer/web/article/v1/web_article.proto";
+import "stroeer/web/section/v1/web_section_page.proto";
 
 option go_package = "github.com/stroeer/tapir/go/stroeer/web/section/v1;section";
 option java_multiple_files = true;
@@ -17,6 +17,6 @@ message GetWebSectionPageRequest {
 }
 
 message GetWebSectionPageResponse {
-  repeated stroeer.web.article.v1.WebArticle web_articles = 1;
+  stroeer.web.section.v1.WebSectionPage web_section_page = 1;
 }
 


### PR DESCRIPTION
# WebSection API message definition and gprc service

## This is a *Draft PR* - everything is up for discussion. Actual implementation only serves as a entry point for discussion

## necessary discussion
### how to release model?
- breaking change v1?
- add v2 ?
- additive v1?
**-> Apps will use API much later -> lets to breaking change**

### reuse message definitions from old section service?
- e.g. GetWebSectionPageRequest, GetWebSectionPageResponse
- **buf linter says NO**
-> will be resolved by breaking change
**-> accept buf rules to only respond with object wrappers to support later adding of new fields like metadata (paging information e.g.)**

### Keep number of protobuf message definitions small
- replace Container message with recursive TeaserStage message
  - TeaserStage itself would have field `repeated TeaserStage teaser_stages = 1;`
**-> agreed on ✅ **
### Incremental vs anticipatory message definition 
- remember that protobuf does not support Inheritance, so the more subtypes we want to support with one message definition, the more fields exist that are only relevant for some subtypes
- **`ApiStageConfiguration`**
  - currently the headline for a TeaserStage is a String
  - In the past project we had an `ApiStageConfiguration` model, which allowed configuring:
    - a label
    - a logo
    - href for label / logo
    - adding a submenu for a stage to produce more clicks on particular sections, themepages or articles
    - and much more, which demonstrates the growing needs over time
- **`ApiTeaserConfig`**
  - currently the StageLayout only contains a `layout_id`
  - In the past project we had a stage layout in the `ApiStageConfiguration` and also an `ApiTeaserConfig` to change a single teasers layout and/or (grid-) size 
    - Some StageLayouts purposely ignored the individual Teaser Layouts, like the Newsticker Layout, which rendered articles as simple text teasers, sorted by new
  - Do we need individual Teaser Styling or are StageLayouts and content types enough to render requirements in the designs
  - Do we need fields in the Layout object to reduce duplicating a layout just to change the background color from `white` to `grey` or `blarz`?
- Additive protobuf messages vs breaking downwards compatibility
  - We could start small - only the fields that we need today
  - `protobuf` aims to be downwards compatible by allowing additive changes only
  - which would lead to a lot of deprecated fields if we don't want breaking changes
  - We will have external teams consuming our API, so breaking changes are not manageable just within our team 

### How to place Ads?
- Placeholders
  - add placeholders to list of teaser?
  - add ad format information to `ApiStageConfiguration` as in the past project?
    - lead to iterating over the teasers twice in the frontend code to place the Ad Container at the appropriate position
- ad format ids 
  - should format ids be part of the backend response?
  - Different channels, like the native apps will probably use a different app sdk with different ad formats

**Idea:** 
- Add abstract Ad-Placeholders to the list of teasers of a stage
  - ads are part of content, and not configuration
  - placeholders must be mapped in the renderers to their proprietary ad formats
  - e.g. "ContentSizedAd" may be a Medium Rectangle in the www, but something diffent in the native apps
  - add `UberTeaser` message definition which can be a AdPlaceHolder, a WebArticle or something like an oembed

### How to inherit SectionTool 2.0 configuration within the "Section Tree"
- Think of a `Regionales` section, which defines a sub menu that should be rendered on all sub sections
- Do we need to structure the messages so that the inheritance concept of the future will not get complicated?
  - Think of Refactoring to `ApiSitebuilding` which held most of the info in a map<string,string>, which offers great flexibility for adding new data without having to release new tapir versions, but makes it hard to only inherit, what is needed.
  - Try to avoid having to extract the fields by something like a prefix (was a pita in the past project)
- Consider the general Trade offs between `flexible models, that don't need regular releases for new fields` and having explicit models that allow for easy, safe and granular inheritance

### Links for reference to past projet models
[ApiStage.scala](https://github.com/spring-media/rbbt-WeltContentApiClient/blob/master/pressed/src/main/scala/de/welt/contentapi/pressed/models/ApiStage.scala)

## visual mapping between figma design and message definitions
![design_field_mapping](https://user-images.githubusercontent.com/3657550/94587098-6812d200-0282-11eb-8101-68df552405cb.png)



