### PR TITLE
tapir API docs wiki generator

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -1,4 +1,4 @@
-name: publish
+name: wiki-docs-generator
 
 on:
   release:
@@ -21,8 +21,8 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           cd tapir.wiki
-          cd tapir.wiki
-          [ -d api-specs/$RELEASE_TAG ] || mkdir -p api-specs/$RELEASE_TAG
+          [ -d api-spec
+          s/$RELEASE_TAG ] || mkdir -p api-specs/$RELEASE_TAG
           yes | cp ../api-docs/api-spec* ./api-specs/$RELEASE_TAG
           cd ./api-specs/$RELEASE_TAG
           echo "\n\n## $RELEASE_TAG \n" >> ../../api-spec.md

--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -8,7 +8,8 @@ jobs:
   docs:
     env:
       RELEASE_TAG: ${{ github.event.release.tag_name }}
-      SPEC_FOLDER: api-specs/${{ github.event.release.tag_name }}
+      RELEASE_SPEC_FOLDER: api-docs/${{ github.event.release.tag_name }}
+      SPEC_FILE_NAME: api-spec.md
     steps:
       - uses: actions/checkout@v2
       - name: Gen docs
@@ -19,16 +20,14 @@ jobs:
           repository: ${{github.repository}}.wiki
       - name: add docs to api-spec.md
         run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
           cd tapir.wiki
           [ -d $SPEC_FOLDER ] || mkdir -p $SPEC_FOLDER
-          yes | cp ../api-docs/api-spec* $SPEC_FOLDER
-          cd $SPEC_FOLDER
-          echo "\n\n## $RELEASE_TAG \n" >> ../../api-spec.md
-          for n in api-spec-stroeer*; do filepath=${n/.md/}; label=${filepath/api-spec-/}; echo "• [$label]($SPEC_FOLDER/$filepath)" >> ../../api-spec.md; done
-          cd ../..
+          yes | cp -r ../$SPEC_FOLDER .
+          echo "• [$RELEASE_TAG]($RELEASE_SPEC_FOLDER/$SPEC_FILE_NAME)" >> ../../api-spec.md
+          cd ..
       - name: push changed docs to wiki
         run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
           git add .
           git diff-index --quiet HEAD || git commit -m "update wiki api-specs" && git push

--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -1,0 +1,32 @@
+name: publish
+
+on:
+  release:
+    types: [published, edited]
+
+jobs:
+  docs:
+    env:
+      RELEASE_TAG: ${{ github.event.release.tag_name }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Gen docs
+        run: make
+      - name: Checkout wiki code
+        uses: actions/checkout@v2
+        with:
+          repository: ${{github.repository}}.wiki
+      - name: Write docs to wiki
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          cd tapir.wiki
+          cd tapir.wiki
+          [ -d api-specs/$RELEASE_TAG ] || mkdir -p api-specs/$RELEASE_TAG
+          yes | cp ../api-docs/api-spec* ./api-specs/$RELEASE_TAG
+          cd ./api-specs/$RELEASE_TAG
+          echo "\n\n## $RELEASE_TAG \n" >> ../../api-spec.md
+          for n in api-spec-stroeer*; do filepath=${n/.md/}; label=${filepath/api-spec-/}; echo "• [$label](api-specs/$RELEASE_TAG/$filepath)" >> ../../api-spec.md; done
+          cd ../..
+          git add .
+          git diff-index --quiet HEAD || git commit -m "Update api-specs" && git push

--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: ${{github.repository}}.wiki
-      - name: Write docs to wiki
+      - name: add docs to api-spec.md
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
@@ -28,5 +28,7 @@ jobs:
           echo "\n\n## $RELEASE_TAG \n" >> ../../api-spec.md
           for n in api-spec-stroeer*; do filepath=${n/.md/}; label=${filepath/api-spec-/}; echo "• [$label](api-specs/$RELEASE_TAG/$filepath)" >> ../../api-spec.md; done
           cd ../..
+      - name: push changed docs to wiki
+        run: |
           git add .
-          git diff-index --quiet HEAD || git commit -m "Update api-specs" && git push
+          git diff-index --quiet HEAD || git commit -m "update wiki api-specs" && git push

--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -8,6 +8,7 @@ jobs:
   docs:
     env:
       RELEASE_TAG: ${{ github.event.release.tag_name }}
+      SPEC_FOLDER: api-specs/${{ github.event.release.tag_name }}
     steps:
       - uses: actions/checkout@v2
       - name: Gen docs
@@ -21,12 +22,11 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           cd tapir.wiki
-          [ -d api-spec
-          s/$RELEASE_TAG ] || mkdir -p api-specs/$RELEASE_TAG
-          yes | cp ../api-docs/api-spec* ./api-specs/$RELEASE_TAG
-          cd ./api-specs/$RELEASE_TAG
+          [ -d $SPEC_FOLDER ] || mkdir -p $SPEC_FOLDER
+          yes | cp ../api-docs/api-spec* $SPEC_FOLDER
+          cd $SPEC_FOLDER
           echo "\n\n## $RELEASE_TAG \n" >> ../../api-spec.md
-          for n in api-spec-stroeer*; do filepath=${n/.md/}; label=${filepath/api-spec-/}; echo "• [$label](api-specs/$RELEASE_TAG/$filepath)" >> ../../api-spec.md; done
+          for n in api-spec-stroeer*; do filepath=${n/.md/}; label=${filepath/api-spec-/}; echo "• [$label]($SPEC_FOLDER/$filepath)" >> ../../api-spec.md; done
           cd ../..
       - name: push changed docs to wiki
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,6 @@ COPY --from=node /node_modules /node_modules
 COPY --from=protoc-bin /installer/protoc /usr/bin/protoc
 COPY --from=protoc-bin /installer/protoc-gen-doc /usr/bin/protoc-gen-doc
 RUN chmod +x /usr/bin/protoc-gen-grpc-java
-RUN chmod +x /usr/bin/protoc-gen-grpc-java
 
 ENV PATH="/usr/bin/protoc/bin:${PATH}"
 RUN protoc --version

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,20 @@
 
-# Protoc binary
+# Protoc binaries
 FROM node:lts-alpine as protoc-bin
 ARG PROTOC_VERSION
+# protoc bin
 RUN mkdir /installer
 RUN wget https://github.com/protocolbuffers/protobuf/releases/download/v$PROTOC_VERSION/protoc-$PROTOC_VERSION-linux-x86_64.zip -O protoc.zip
 RUN mkdir -p /installer/protoc
 RUN unzip -o protoc.zip -d /installer/protoc/
+RUN ls -al /installer/protoc
 
+# protoc-gen-doc bin
+USER root
+RUN wget https://github.com/pseudomuto/protoc-gen-doc/releases/download/v1.3.2/protoc-gen-doc-1.3.2.linux-amd64.go1.12.6.tar.gz  -O protoc-gen-doc.tar.gz
+RUN tar --extract --file=protoc-gen-doc.tar.gz --strip-components 1 -C /installer
+RUN chown root:root /installer/protoc-gen-doc
+RUN ls -al /installer/
 
 # Node
 FROM node:lts-alpine as node
@@ -17,9 +25,7 @@ RUN npm ci
 
 # Java
 FROM gradle:latest as java
-
 COPY java .
-
 RUN gradle download
 RUN mv installer /
 
@@ -42,7 +48,8 @@ COPY --from=gopher /go/bin/protoc-gen-go-grpc /usr/bin/
 COPY --from=java /installer/protoc-gen-grpc-java /usr/bin/
 COPY --from=node /node_modules /node_modules
 COPY --from=protoc-bin /installer/protoc /usr/bin/protoc
-
+COPY --from=protoc-bin /installer/protoc-gen-doc /usr/bin/protoc-gen-doc
+RUN chmod +x /usr/bin/protoc-gen-grpc-java
 RUN chmod +x /usr/bin/protoc-gen-grpc-java
 
 ENV PATH="/usr/bin/protoc/bin:${PATH}"

--- a/Makefile
+++ b/Makefile
@@ -13,16 +13,18 @@ DIR = $(shell pwd)
 JAVA_DIR = ./java/src/main/java
 NODE_DIR = ./node
 GO_DIR = ./go
+DOCS_DIR = ./api-docs
 
 OUTPUT ?= $(JAVA_DIR)
 LANGUAGE ?= java
-GRPCPLUGIN ?= /usr/bin/protoc-gen-grpc-$(LANGUAGE)
+GRPC_PLUGIN ?= /usr/bin/protoc-gen-grpc-$(LANGUAGE)
 
 PROTOC_VERSION ?= 3.13.0
 
 PROTOC ?= docker run --rm -v $(DIR):$(DIR) -w $(DIR) ghcr.io/stroeer/protoc-dockerized:$(PROTOC_VERSION)
 
 FLAGS+= --proto_path=$(DIR)
+FLAGS+= --doc_opt=markdown,package.md
 ifeq ($(LANGUAGE),node)
 	ifeq ($(OUTPUT), $(JAVA_DIR))
 		OUTPUT = $(NODE_DIR)
@@ -42,7 +44,7 @@ else ifeq ($(LANGUAGE),go)
 	FLAGS+= --$(LANGUAGE)-grpc_opt=paths=source_relative
 else
 	FLAGS+= --$(LANGUAGE)_out=$(OUTPUT)
-	FLAGS+=	--plugin=protoc-gen-grpc=$(GRPCPLUGIN)
+	FLAGS+=	--plugin=protoc-gen-grpc=$(GRPC_PLUGIN)
 	FLAGS+= --grpc_out=$(OUTPUT)
 endif
 
@@ -50,30 +52,40 @@ endif
 
 all: stroeer/*
 
+doc-folders: clean-docs
+	@echo "+ docsdir $@"
+	find stroeer/* -type d -depth 0 | xargs -L1 -I{} mkdir -p $(DOCS_DIR)/"{}"
+
 $(OUTPUT):
-	@echo "+ $@"
+	@echo "+ mkdir $@"
 	[ -d $@ ] || mkdir -p $@
 
-stroeer/%: $(OUTPUT)
-	@echo "+ $@"
-	$(PROTOC) $(FLAGS) $(shell find $@ -iname "*.proto" -exec echo -n '"{}" ' \; | tr '\n' ' ')
+
+stroeer/%: $(OUTPUT) doc-folders
+	@echo "+ compile: $@"
+	$(PROTOC) $(FLAGS) --doc_out=$(DOCS_DIR)/$@ $(shell find $@ -iname "*.proto" -exec echo -n '"{}" ' \; | tr '\n' ' ')
 
 clean: ## Deletes all generated files
 	@echo "+ $@"
-	rm -rf $(JAVA_DIR) || true
-	rm -rf `find $(GO_DIR) -type d \( -iname "*" ! -iname "go.mod" ! -iname "go.sum" ! -iname "*_test.go" \) -mindepth 1 -maxdepth 1` 2> /dev/null || true
-	rm -rf `find $(NODE_DIR) -type d \( -iname "*" ! -iname "node_modules" ! -iname "__tests__" \) -mindepth 1 -maxdepth 1` 2> /dev/null || true
+	@rm -rf $(JAVA_DIR) || true
+	@rm -rf `find $(GO_DIR) -type d \( -iname "*" ! -iname "go.mod" ! -iname "go.sum" ! -iname "*_test.go" \) -mindepth 1 -maxdepth 1` 2> /dev/null || true
+	@rm -rf `find $(NODE_DIR) -type d \( -iname "*" ! -iname "node_modules" ! -iname "__tests__" \) -mindepth 1 -maxdepth 1` 2> /dev/null || true
 
-image-build: ## Build new docker image
+clean-docs:
+	@if [[ $(DOCS_DIR)/* == /* ]]; then echo "var DOCS_DIR is unset, prevented 'rm -rf /*'"; else rm -rf $(DOCS_DIR)/*; fi
+
+docker-build: ## Build new docker image
 	docker build \
 		-t ghcr.io/stroeer/protoc-dockerized:latest \
 		-t ghcr.io/stroeer/protoc-dockerized:$(PROTOC_VERSION) \
 		--build-arg PROTOC_VERSION=$(PROTOC_VERSION) .
 
-image-release: image-build ## Release new docker image to GHCR
+docker-push: image-build ## Release new docker image to GHCR
 	docker push ghcr.io/stroeer/protoc-dockerized:latest
 	docker push ghcr.io/stroeer/protoc-dockerized:$(PROTOC_VERSION)
 
-
 help: ## Display this help screen
 	@grep -E '^[0-9a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+dev-release-java: clean java stroeer/*
+	cd java; ./gradlew publishToMavenLocal

--- a/README.md
+++ b/README.md
@@ -89,5 +89,5 @@ Login to `ghcr.io` with your Github user name and a Github personal access token
 cat ${TOKEN_FILE_LOCATION} | docker login ghcr.io -u ${GH_USERNAME} --password-stdin
 ```
 
-- run `make image-build` (tags as [`$protoc_version`, `latest`])
-- run `make image-release` to push the new image
+- run `make docker-build` (tags as [`$protoc_version`, `latest`])
+- run `make docker-release` to push the new image

--- a/create-docu.sh
+++ b/create-docu.sh
@@ -1,0 +1,14 @@
+export RELEASE_TAG=0.1.2
+cd tapir.wiki
+[ -d api-specs/$RELEASE_TAG ] || mkdir -p api-specs/$RELEASE_TAG
+yes | cp ../api-docs/api-spec* ./api-specs/$RELEASE_TAG
+cd ./api-specs/$RELEASE_TAG
+echo "\n\n## $RELEASE_TAG \n" >> ../../api-spec.md
+for n in api-spec-stroeer*; do filepath=${n/.md/}; label=${filepath/api-spec-/}; echo "• [$label](api-specs/$RELEASE_TAG/$filepath)" >> ../../api-spec.md; done
+cd ../..
+git diff api-spec.md
+cat api-spec.md
+rm -rf api-specs/*
+git restore api-specs
+git restore api-spec.md
+cd ..


### PR DESCRIPTION
# What
- [Dockerfile] add binary for protoc for generating docs from proto files
- [Makefile] add target to generate docs for all of /stroeer in one `api-spec.md`
- [CI] add workflow to add a link into the index file `api-spec.md` to the specs for the release

# Why
- Will produce this: https://github.com/stroeer/tapir/wiki/api-spec
- #84

# Comment
- generated docu relies on proper comments in files
  - see an example here:  https://github.com/stroeer/tapir/pull/83
- syntax for comments:
  - https://github.com/pseudomuto/protoc-gen-doc#writing-documentation

# Beware
- checks fail because docker image with the new binary was not pushed yet

