### PR TITLE
chore(node): bump dependencies for protoc 3.14.0

### DIFF
--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -2332,9 +2332,9 @@
       }
     },
     "google-protobuf": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.13.0.tgz",
-      "integrity": "sha512-ZIf3qfLFayVrPvAjeKKxO5FRF1/NwRxt6Dko+fWEMuHwHbZx8/fcaAao9b0wCM6kr8qeg2te8XTpyuvKuD9aKw==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.14.0.tgz",
+      "integrity": "sha512-bwa8dBuMpOxg7COyqkW6muQuvNnWgVN8TX/epDRGW5m0jcrmq2QJyCyiV8ZE2/6LaIIqJtiv9bYokFhfpy/o6w==",
       "dev": true
     },
     "graceful-fs": {
@@ -2351,9 +2351,9 @@
       "optional": true
     },
     "grpc-tools": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/grpc-tools/-/grpc-tools-1.9.1.tgz",
-      "integrity": "sha512-t2JFMPLjxcgwVSJwFEauFaoEiO56kijxSwehQDgZNR/hrStJCH0pHGsjqJNuCOvmI9Z31pYOfgj4zeInTQWh5A==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/grpc-tools/-/grpc-tools-1.10.0.tgz",
+      "integrity": "sha512-tEbO16TuXV+aJPTMK4FCd4Jw6uzR/wm4h3u27MmZQlWLETp3bL/6KQdVM6xujNx8N1Mbj0/Be2f/0SedzGm0dQ==",
       "dev": true,
       "requires": {
         "node-pre-gyp": "^0.15.0"
@@ -4209,9 +4209,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stroeer/tapir-v1",
-  "version": "0.6.0",
+  "version": "0.11.0",
   "description": "T-Online API Repo",
   "scripts": {
     "checks": "npm run lint && npm run test",
@@ -12,8 +12,8 @@
     "@grpc/grpc-js": "1.2.1",
     "@types/google-protobuf": "3.7.4",
     "@types/jest": "26.0.15",
-    "google-protobuf": "3.13.0",
-    "grpc-tools": "1.9.1",
+    "google-protobuf": "3.14.0",
+    "grpc-tools": "1.10.0",
     "jest": "26.6.3",
     "jest-circus": "26.6.3",
     "prettier": "2.2.0",
@@ -23,7 +23,7 @@
   },
   "peerDependencies": {
     "@grpc/grpc-js": "^1.2.0",
-    "google-protobuf": "^3.13.0"
+    "google-protobuf": "^3.14.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I guess this is not critical at all but I like to align this versions together.

See #119 