### PR TITLE
feat(model): shared page data

### DIFF
--- a/stroeer/core/v1/article.proto
+++ b/stroeer/core/v1/article.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package stroeer.core.v1;
 
 import "google/protobuf/timestamp.proto";
+import "stroeer/core/v1/shared.proto";
 
 option go_package = "github.com/stroeer/tapir/go/stroeer/core/v1;core";
 option java_multiple_files = true;
@@ -30,10 +31,10 @@ message Article {
 
   // References to get access to the article on different technical platforms like
   // canonical web or AMP (required).
-  References references = 4;
+  stroeer.core.v1.References references = 4;
 
-  // Hierarchical section information of the article (required).
-  Section section = 5;
+  // Hierarchical section tree information of the article (required).
+  stroeer.core.v1.SectionTree section_tree = 5;
 
   // Generic map containing general content and configuration information of
   // the article (required).
@@ -146,34 +147,6 @@ message Asset {
 
   // Technical metadata of the asset.
   Metadata metadata = 3;
-}
-
-// Hierarchical section information of the article till root.
-//
-// For example:  /politik/deutschland/ -> /politik/ -> /
-message Section {
-  // Section path of the article, e.g. /politik/deutschland/ (required).
-  string path = 1;
-
-  // Label of the section path, e.g. "Politik".
-  string label = 2;
-
-  // Parent section. Usually points to the parent section, if there is none, e.g. when in `root` this value is `null`
-  Section parent = 3;
-}
-
-// References to get access to the article on different technical platforms like
-// canonical web or AMP.
-message References {
-  // URL path for this article e.g. /section/id_$ID/title.html (required).
-  string path = 1;
-
-  // Canonical URL of the article, may differ if external, e.g. https://www.giga.de/external.html
-  // (required).
-  string canonical = 2;
-
-  // AMP URL of the article.
-  string amp = 3;
 }
 
 // Body of the article to render on detail pages.

--- a/stroeer/core/v1/shared.proto
+++ b/stroeer/core/v1/shared.proto
@@ -1,0 +1,36 @@
+syntax = "proto3";
+
+package stroeer.core.v1;
+
+option go_package = "github.com/stroeer/tapir/go/stroeer/core/v1;core";
+option java_multiple_files = true;
+option java_package = "de.stroeer.core.v1";
+
+
+// References to get access to the article on different technical platforms like
+// canonical web or AMP.
+message References {
+  // URL path for this article e.g. /section/id_$ID/title.html (required).
+  string path = 1;
+
+  // Canonical URL of the article, may differ if external, e.g. https://www.giga.de/external.html
+  // (required).
+  string canonical = 2;
+
+  // AMP URL of the article.
+  string amp = 3;
+}
+
+// Hierarchical section information of the article till root.
+//
+// For example:  /politik/deutschland/ -> /politik/ -> /
+message SectionTree {
+  // Section path of the article, e.g. /politik/deutschland/ (required).
+  string path = 1;
+
+  // Label of the section path, e.g. "Politik".
+  string label = 2;
+
+  // Parent section. Usually points to the parent section, if there is none, e.g. when in `root` this value is `null`
+  SectionTree parent = 3;
+}

--- a/stroeer/page/section/v1/section_page.proto
+++ b/stroeer/page/section/v1/section_page.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package stroeer.page.section.v1;
 
+import "stroeer/core/v1/shared.proto";
 import "stroeer/core/v1/article.proto";
 
 option go_package = "github.com/stroeer/tapir/go/stroeer/page/section/v1;section";
@@ -10,7 +11,18 @@ option java_package = "de.stroeer.page.section.v1";
 
 // All data to render a section page like the homepage or "/politik/".
 message SectionPage {
-  repeated Stage stages = 1;
+  repeated Section section = 1;
+  repeated Stage stages = 2;
+}
+
+// All meta information to render a section page
+message Section {
+  // References to get access to the section on different technical platforms like
+  // canonical web or AMP (required).
+  stroeer.core.v1.References references = 1;
+
+  // Hierarchical section tree information of the section (required).
+  stroeer.core.v1.SectionTree section_tree = 2;
 }
 
 // A block of teasers - can consist of editorial articles, advertisement and/or stages.


### PR DESCRIPTION
Introducing a new message type for `SectionPage` to access all kind data to render a page's meta data or shared content. This message type contains the same data as the `Article` message. For this reason I renamed the message type `Section` to `SectionTree` to align the page field wordings.

```proto
// only for clarification:

message Article {
  References references = ?;
  SectionTree section_tree = ?;
  // ... more 
}

message Section {
  References references = ?;
  SectionTree section_tree = ?;
  // ... more 
}

message ArticlePage {
  Article article = 1;
  // ... more 
}

message SectionPage {
  Section section = 1;
  // ... more 
}
```

fixes #149