### PR TITLE
PoC: use Google API linter on GH

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           go-version: '^1.16'
 
-      - run: go install github.com/googleapis/api-linter/cmd/api-linter
+      - run: go install github.com/googleapis/api-linter/cmd/api-linter@v1.15.0
 
       - name: Google API linter
         run: api-linter --output-format stroeer/core/v1/article.proto

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -6,6 +6,18 @@ on:
       - master
 
 jobs:
+  api-linter:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-go@v2
+
+      - run: go get -u github.com/googleapis/api-linter/cmd/api-linter
+
+      - name: Google API linter
+        run: api-linter --output-format stroeer/core/v1/article.proto
+
   buf:
     runs-on: ubuntu-latest
     container: bufbuild/buf

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -15,10 +15,10 @@ jobs:
         with:
           go-version: '^1.16'
 
-      - run: go install github.com/googleapis/api-linter/cmd/api-linter@v1.15.0
+      - run: go install github.com/googleapis/api-linter/cmd/api-linter@latest
 
       - name: Google API linter
-        run: api-linter --output-format stroeer/core/v1/article.proto
+        run: make lint
 
   buf:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,8 +12,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: actions/setup-go@v2
+        with:
+          go-version: '^1.16'
 
-      - run: go get -u github.com/googleapis/api-linter/cmd/api-linter
+      - run: go install github.com/googleapis/api-linter/cmd/api-linter
 
       - name: Google API linter
         run: api-linter --output-format stroeer/core/v1/article.proto

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,13 @@ stroeer/%: $(OUTPUT)
 	@echo "+ $@"
 	$(PROTOC) $(FLAGS) $(shell find $@ -iname "*.proto" -exec echo -n '"{}" ' \; | tr '\n' ' ')
 
+tools: ## Checks for local availability of tools
+	@command -v api-linter >/dev/null 2>&1 || { echo >&2 "Please install api-linter: 'go install github.com/googleapis/api-linter/cmd/api-linter@latest'"; exit 1; }
+
+lint: tools ## Lints all proto files using Google API linter (https://linter.aip.dev/)
+	@echo "+ $@"
+	@api-linter $(shell find stroeer -iname "*.proto" -exec echo -n '"{}" ' \; | tr '\n' ' ') --output-format summary --set-exit-status || exit 1
+
 gateway: ## Generates grpc-gateway resources
 	@echo "+ $@"
 	$(PROTOC) -I . --grpc-gateway_out $(GO_DIR) \


### PR DESCRIPTION
Added https://linter.aip.dev/ to makefile and PR workflow using default rules.

This results in something like this

```
2021/02/24 15:29:44 found problems during linting
+------------------------------------+------------------+----------------+
|                RULE                | TOTAL VIOLATIONS | VIOLATED FILES |
+------------------------------------+------------------+----------------+
| core::0140::abbreviations          |                2 |              1 |
| core::0131::response-message-name  |                3 |              3 |
| core::0131::request-name-required  |                4 |              4 |
| core::0127::http-annotation        |                4 |              4 |
| core::0131::request-unknown-fields |                4 |              4 |
| core::0131::method-signature       |                4 |              4 |
| core::0203::optional               |                4 |              3 |
| core::0203::required               |                9 |              4 |
| core::0191::java-outer-classname   |                9 |              9 |
| core::0192::has-comments           |               15 |              4 |
+------------------------------------+------------------+----------------+
Linted 9 proto files
make: *** [lint] Error 1
Makefile:65: recipe for target 'lint' failed
```

No updating of PR comments with step results so far.
