### PR TITLE
gh release worklow based on tags

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @moritzzimmer @harryurban @thisismana @FalkoBasner @bobaaaaa

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -6,17 +6,7 @@ on:
       - 'v*'
 
 jobs:
-  version:
-    runs-on: ubuntu-latest
-    outputs:
-      tag: ${{ steps.version.outputs.tag }}
-    steps:
-      - name: Version
-        id: version
-        run: echo ::set-output name=tag::${GITHUB_REF/refs\/tags\//}
-
   java:
-    needs: version
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -32,17 +22,14 @@ jobs:
       - name: publish
         working-directory: java
         env:
-          TAG: ${{needs.version.outputs.tag}}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo $TAG
-          RELEASE_TAG=$(cut -d "v" -f2 <<< "$TAG")
+          RELEASE_TAG=${GITHUB_REF/refs\/tags\/v/}
           echo $RELEASE_TAG
-          ./gradlew clean build publish
+          ./gradlew -Pversion=$RELEASE_TAG clean build publish
 
   node:
     runs-on: ubuntu-latest
-    needs: version
     steps:
       - uses: actions/checkout@v2
 
@@ -67,11 +54,9 @@ jobs:
       - name: npm publish
         working-directory: node
         env:
-          TAG: ${{needs.version.outputs.tag}}
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo $TAG
-          RELEASE_TAG=$(cut -d "v" -f2 <<< "$TAG")
+          RELEASE_TAG=${GITHUB_REF/refs\/tags\/v/}
           echo $RELEASE_TAG
           npm version $RELEASE_TAG
           npm publish

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -1,0 +1,77 @@
+name: release-packages
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.version.outputs.tag }}
+    steps:
+      - name: Version
+        id: version
+        run: echo ::set-output name=tag::${GITHUB_REF/refs\/tags\//}
+
+  java:
+    needs: version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
+          java-package: jdk
+
+      - name: make
+        run: make
+
+      - name: publish
+        working-directory: java
+        env:
+          TAG: ${{needs.version.outputs.tag}}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo $TAG
+          RELEASE_TAG=$(cut -d "v" -f2 <<< "$TAG")
+          echo $RELEASE_TAG
+          ./gradlew clean build publish
+
+  node:
+    runs-on: ubuntu-latest
+    needs: version
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "14.x"
+          registry-url: "https://npm.pkg.github.com"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: npm ci
+        run: npm ci
+        working-directory: node
+
+      - name: make
+        run: make LANGUAGE=node
+
+      - name: Run node checks
+        run: npm run checks
+        working-directory: node
+
+      - name: npm publish
+        working-directory: node
+        env:
+          TAG: ${{needs.version.outputs.tag}}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo $TAG
+          RELEASE_TAG=$(cut -d "v" -f2 <<< "$TAG")
+          echo $RELEASE_TAG
+          npm version $RELEASE_TAG
+          npm publish

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -30,12 +30,12 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: lint
-        run: buf check lint
+        run: buf lint
 
       - name: check breaking change
         id: buf_breaking
         run: |
-          buf check breaking --against-input 'https://github.com/stroeer/tapir.git#branch=master' --input-config buf.yaml > message.txt || true
+          buf breaking --against 'https://github.com/stroeer/tapir.git#branch=master' --config buf.yaml > message.txt || true
           echo "::set-output name=message::$(cat message.txt)"
           if [ -s message.txt ]; then
             echo ::set-output name=failed::'true';

--- a/java/build.gradle
+++ b/java/build.gradle
@@ -7,15 +7,12 @@ plugins {
 
 ext {
   apiVersion = 'v1'
-  externalVersion = System.getenv("RELEASE_TAG") ?: "0.0.1-SNAPSHOT"
-
   gh_username = System.getenv("GITHUB_ACTOR") ?: (project.findProperty('github.actor') ?: "none")
   gh_token = System.getenv("GITHUB_TOKEN") ?: (project.findProperty('github.token') ?: "none")
 }
 
 group = 'de.stroeer.api.grpc'
 archivesBaseName = "${project.name}-${apiVersion}"
-version = externalVersion
 sourceCompatibility = '11'
 
 repositories {

--- a/java/gradle.properties
+++ b/java/gradle.properties
@@ -1,0 +1,2 @@
+# version will be set by GitHub workflow
+version=0.0.1-SNAPSHOT


### PR DESCRIPTION
Created a new workflow based on Git tags with a go modules compatible scheme (`vX.X.X`). Version of java and node packages still use the identifier without the `v`.

Examples: a new tag with `v0.0.1` should release `de.stroeer.api.grpc.tapir-v1:0.0.1` for java

After this we should improve automatic releases based on tags in https://github.com/stroeer/tapir/issues/57