### PR TITLE
Enhanced release process

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: lint
-        run: make lint
+        run: buf lint
 
       - name: check breaking change
         id: buf_breaking

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -6,20 +6,6 @@ on:
       - master
 
 jobs:
-  api-linter:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: actions/setup-go@v2
-        with:
-          go-version: '^1.16'
-
-      - run: go install github.com/googleapis/api-linter/cmd/api-linter@latest
-
-      - name: Google API linter
-        run: make lint
-
   buf:
     runs-on: ubuntu-latest
     container: bufbuild/buf
@@ -30,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: lint
-        run: buf lint
+        run: make lint
 
       - name: check breaking change
         id: buf_breaking
@@ -52,16 +38,6 @@ jobs:
             ```
             ${{ steps.buf_breaking.outputs.message }}
             ```
-          check_for_duplicate_msg: false
-
-      - if: steps.buf_breaking.outputs.failed != 'true'
-        name: comment PR
-        uses: unsplash/comment-on-pr@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          msg: |
-            ## :white_check_mark: No Breaking Changes
           check_for_duplicate_msg: false
 
   java:
@@ -108,9 +84,8 @@ jobs:
 
       - uses: actions/setup-go@v2
 
-      # (in contrast to localhost) w/o the '--always-make' option, this target is always up-to-date on GitHub actions. Don't know why, yet
       - name: make
-        run: make LANGUAGE=go --always-make
+        run: make LANGUAGE=go
 
       - name: go test
         run: go test -v .

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -50,8 +50,7 @@ jobs:
           java-version: 11
           java-package: jdk
 
-      - name: make
-        run: make
+      - run: make LANGUAGE=java
 
       - name: build
         run: ./gradlew clean build
@@ -70,8 +69,7 @@ jobs:
         run: npm ci
         working-directory: node
 
-      - name: make
-        run: make LANGUAGE=node
+      - run: make LANGUAGE=node
 
       - name: Run node checks
         run: npm run checks
@@ -84,9 +82,19 @@ jobs:
 
       - uses: actions/setup-go@v2
 
-      - name: make
-        run: make LANGUAGE=go
+      - run: make LANGUAGE=go
+
+      - run: make gateway
 
       - name: go test
         run: go test -v .
         working-directory: go
+
+      - name: Verifies clean working directory
+        run: |
+          if output=$(git status --porcelain) && [ -z "$output" ]; then
+            echo "Go source code is up-to-date";
+          else
+            echo "Detected changes in generated Go source code!";
+            exit 1;
+          fi

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ all: $(PROTO_FILES)
 	@mkdir -p $(OUTPUT)
 	$(PROTOC) $(FLAGS) $*.proto
 
-LANGUAGES := java node go
+LANGUAGES ?= java node go
 generate: $(LANGUAGES) ## Generates source files for all supported languages
 
 $(LANGUAGES):

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The **T**-online **API** **R**epository contains the interface definitions of t-
 
 T-online APIs use [Protocol Buffers](https://github.com/google/protobuf) version 3 (proto3) as their Interface Definition Language (IDL) to define the API interface and the structure of the payload messages.
 
-## Guidelines
+## guidelines
 
 * tapir provides an [IDL](https://en.wikipedia.org/wiki/Interface_description_language) and RCP services stubs to access editorial content and their configuration. This allows delivering various t-online products developed by independent teams
 * RPC services and proto messages are optimized for an efficient development and delivery of those products: One of our internal API guideline demands that all the content required to render a page must depend on a single API call.
@@ -22,7 +22,7 @@ T-online APIs use [Protocol Buffers](https://github.com/google/protobuf) version
 * proto message fields and entries of maps are optional unless commented otherwise. Clients must not break if an optional field or map entry is missing.
  
 
-## Code generation
+## code generation
 
 We provide [stroeer/protoc-dockerized](https://github.com/orgs/stroeer/packages/container/package/protoc-dockerized) as `protoc` 
 and a Makefile tested to generate code for `java`, `node (TypeScript)` and `go`:
@@ -34,31 +34,33 @@ $ make LANGUAGE=[java,node,go]
 [stroeer/protoc-dockerized](https://github.com/orgs/stroeer/packages/container/package/protoc-dockerized) also supports generating
 a [grpc-gateway](https://github.com/grpc-ecosystem/grpc-gateway) reverse-proxy server.
 
-## Client libraries
+## client libraries
 
 [Releases](https://github.com/stroeer/tapir/releases) include client libraries as `java` and `npm` [packages](https://github.com/orgs/stroeer/packages?repo_name=tapir). 
 
 Generating go code is currently not part of the release process. Go sources need to be generated locally and added to pull requests.
 
-## Docker image
+## protoc docker image
 
-### Version management
+We provide [stroeer/protoc-dockerized](https://github.com/orgs/stroeer/packages/container/package/protoc-dockerized) including `protoc` and all required
+grpc plugins to generate source code for `java`, `node` and `go`. This docker image also supports generating a [grpc-gateway](https://github.com/grpc-ecosystem/grpc-gateway) 
+reverse-proxy server.
 
-bump versions in a PR and merge into `master`:
+### release
 
-- protoc version in `Makefile`
-- go dependency versions in `go.mod`
-- java dependency versions in `build.gradle`
-- node dependency versions in `package.json`
+1. bump versions
+   
+    - protoc version in `Makefile` - this version will be used as the docker image tag
+    - go dependency versions in `go.mod`
+    - java dependency versions in `build.gradle`
+    - node dependency versions in `package.json`
 
-### Release
 
-Login to `ghcr.io` with your Github user name and a Github personal access token having permissions to `read:packages`, `write:packages` and/or `delete:packages`:
+2. Export actor and token for the [GitHub container registry](https://docs.github.com/en/packages/guides/about-github-container-registry)
+   
+   - `export GITHUB_ACTOR={yourusername}`
+   - `export GITHUB_TOKEN={yourtoken}` (needs `read:packages`, `write:packages`, `delete:packages` permissions)
 
-```sh
-cat ${TOKEN_FILE_LOCATION} | docker login ghcr.io -u ${GH_USERNAME} --password-stdin
-```
 
-- run `make image-build` (tags as [`$protoc_version`, `latest`])
-- run `make image-release` to push the new image
-
+3. build and push protoc docker image
+    - `make protoc-push`

--- a/README.md
+++ b/README.md
@@ -9,7 +9,11 @@ The **T**-online **API** **R**epository contains the interface definitions of t-
 
 T-online APIs use [Protocol Buffers](https://github.com/google/protobuf) version 3 (proto3) as their Interface Definition Language (IDL) to define the API interface and the structure of the payload messages.
 
-## guidelines
+## overview
+
+**TODO**
+
+### guidelines
 
 * tapir provides an [IDL](https://en.wikipedia.org/wiki/Interface_description_language) and RCP services stubs to access editorial content and their configuration. This allows delivering various t-online products developed by independent teams
 * RPC services and proto messages are optimized for an efficient development and delivery of those products: One of our internal API guideline demands that all the content required to render a page must depend on a single API call.
@@ -22,19 +26,22 @@ T-online APIs use [Protocol Buffers](https://github.com/google/protobuf) version
 * proto message fields and entries of maps are optional unless commented otherwise. Clients must not break if an optional field or map entry is missing.
  
 
-## code generation
+## generate gRPC source code
 
-We provide [stroeer/protoc-dockerized](https://github.com/orgs/stroeer/packages/container/package/protoc-dockerized) as `protoc` 
-and a Makefile tested to generate code for `java`, `node (TypeScript)` and `go`:
+To generate gRPC source code for t-online APIs you need to install `protoc` and gRPC on your local machine,
+or you can use our [protoc docker image](#protoc-docker-image) which includes all required plugins for `java`, `node` and `go` source code 
+generation. Then you can run `make LANGUAGE=xxx` to generate the source code for a specific language.
 
-```shell script
-$ make LANGUAGE=[java,node,go]
-``` 
+It's also possible to generate gRPC source code for all languages (define by the `LANGUAGES` variable) at once: `make generate`.
 
-[stroeer/protoc-dockerized](https://github.com/orgs/stroeer/packages/container/package/protoc-dockerized) also supports generating
-a [grpc-gateway](https://github.com/grpc-ecosystem/grpc-gateway) reverse-proxy server.
+### quality assurance
 
-## client libraries
+We use [buf](https://buf.build/) to lint our proto files and to detect breaking changes. In addition, we run some basic language specific tests to verify a
+successful code generation for `java`, `node` and `go`. Run `make check` to run all checks.
+
+### client libraries
+
+**TODO**
 
 [Releases](https://github.com/stroeer/tapir/releases) include client libraries as `java` and `npm` [packages](https://github.com/orgs/stroeer/packages?repo_name=tapir). 
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@ T-online APIs use [Protocol Buffers](https://github.com/google/protobuf) version
 
 ## overview
 
-**TODO**
-
 ### guidelines
 
 * tapir provides an [IDL](https://en.wikipedia.org/wiki/Interface_description_language) and RCP services stubs to access editorial content and their configuration. This allows delivering various t-online products developed by independent teams
@@ -30,22 +28,25 @@ T-online APIs use [Protocol Buffers](https://github.com/google/protobuf) version
 
 To generate gRPC source code for t-online APIs you need to install `protoc` and gRPC on your local machine,
 or you can use our [protoc docker image](#protoc-docker-image) which includes all required plugins for `java`, `node` and `go` source code 
-generation. Then you can run `make LANGUAGE=xxx` to generate the source code for a specific language.
+generation. 
 
-It's also possible to generate gRPC source code for all languages (define by the `LANGUAGES` variable) at once: `make generate`.
+Then you can run `make LANGUAGE=xxx` to generate the source code for a specific language.
+
+It's also possible to generate gRPC source code for `java`, `node` and `go` at once: `make generate`.
 
 ### quality assurance
 
 We use [buf](https://buf.build/) to lint our proto files and to detect breaking changes. In addition, we run some basic language specific tests to verify a
-successful code generation for `java`, `node` and `go`. Run `make check` to run all checks.
+successful code generation for `java`, `node` and `go`. 
+
+Run `make check` to run all checks.
 
 ### client libraries
 
-**TODO**
+We generate packages for [java](https://github.com/stroeer/tapir/packages/235034) and [node](https://github.com/stroeer/tapir/packages/235031)
+automatically for each new tag which can be integrated in your build system. In addition, the generated [go source code](go/) is tagged for usage with go modules.
 
-[Releases](https://github.com/stroeer/tapir/releases) include client libraries as `java` and `npm` [packages](https://github.com/orgs/stroeer/packages?repo_name=tapir). 
-
-Generating go code is currently not part of the release process. Go sources need to be generated locally and added to pull requests.
+To create a new release run `make BUMP=[major|minor|patch] release` (defaults to `patch)` in your clean master branch.
 
 ## protoc docker image
 


### PR DESCRIPTION
- new make target to generate all source code (`make generate`) while keeping the possibility to generate only for a specific language
- new make target to test generated source code: `make test`
- integrated buf lint and breaking change detection into make
- reworked publication of protoc docker image
- new make target to release client libraries: `make release`
- check up-to-date go code generation in PR workflow
- documented all changes