### PR TITLE
breaking(api): section data rework

### DIFF
--- a/stroeer/page/article/v1/article_page.proto
+++ b/stroeer/page/article/v1/article_page.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 package stroeer.page.article.v1;
 
 import "stroeer/core/v1/article.proto";
-
+import "stroeer/page/section/v1/section_page.proto";
 option go_package = "github.com/stroeer/tapir/go/stroeer/page/article/v1;article";
 option java_multiple_files = true;
 option java_package = "de.stroeer.page.article.v1";
@@ -15,9 +15,12 @@ message ArticlePage {
   // Unpublished elements will be filtered according to their metadata.
   stroeer.core.v1.Article article = 1;
 
+  repeated stroeer.page.section.v1.StageItem companions = 2;
+
   // Additional related editorial articles. Articles which are not published
   // according to their `Metadata` will be filtered.
-  repeated RelatedArticle related_articles = 2;
+  repeated RelatedArticle related_articles = 3;
+
 }
 
 // An editorial article, which is related to another article.

--- a/stroeer/page/article/v1/article_page.proto
+++ b/stroeer/page/article/v1/article_page.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 package stroeer.page.article.v1;
 
 import "stroeer/core/v1/article.proto";
-import "stroeer/page/section/v1/section_page.proto";
+
 option go_package = "github.com/stroeer/tapir/go/stroeer/page/article/v1;article";
 option java_multiple_files = true;
 option java_package = "de.stroeer.page.article.v1";
@@ -15,12 +15,9 @@ message ArticlePage {
   // Unpublished elements will be filtered according to their metadata.
   stroeer.core.v1.Article article = 1;
 
-  repeated stroeer.page.section.v1.StageItem companions = 2;
-
   // Additional related editorial articles. Articles which are not published
   // according to their `Metadata` will be filtered.
-  repeated RelatedArticle related_articles = 3;
-
+  repeated RelatedArticle related_articles = 2;
 }
 
 // An editorial article, which is related to another article.

--- a/stroeer/page/section/v1/section_page.proto
+++ b/stroeer/page/section/v1/section_page.proto
@@ -38,18 +38,18 @@ message Section {
   stroeer.core.v1.Reference section_tree = 2;
 }
 
-// A block of teasers - can consist of editorial articles, advertisement and/or stages.
+// A "row" of teasers - can consist of editorial articles, advertisement and/or stages.
 message Stage {
-  // contains stage_title from now on
+  // contains stage_title and sub_navs from now on
   StageConfiguration stage_configuration = 1;
   repeated StageItem stage_items = 2;
-  repeated StageItem companions = 3; // if present do 1/4 + 3/4 width, if not use 4/4 stage_items
+  // optional, always render the column with the Title and SubNav from the StageConfiguration
+  repeated StageItem companions = 3;
 }
 
 // Rendering data for a stage, currently only a fields map.
 // Coordinate stage layouts, especially the `default` layout with UI department.
 message StageConfiguration {
-  // * `stage_title`: represents an optional label to be rendered above a Stage, like "CORONAVIRUS".
   // * `stage_layout`: represents a visual layout, which may affect teasers, colors, and other styles.
   // If entry `stage_layout` is missing, use layout `default`.
   // the stage_layout field can be used to configure full page width commercials (e.g. nativendo, t-online empfiehlt)
@@ -64,34 +64,33 @@ message StageConfiguration {
 
 // A single generic item of a stage.
 message StageItem {
-  map<string, string> fields = 2; // "padding-off=true", for commercials, you know
+  map<string, string> fields = 1; // for custom flags like bg_color
   // At most one field will be set at the same time.
   // The delegate of the StageItem can be another Stage, an editorial article or a Commercial.
   oneof stage_item_type {
-    TeaserStage teaser_stage = 3;
-    ArticleTeaser article_teaser = 4;
-    Commercial commercial = 5;
+    TeaserStage stage = 2;
+    ArticleTeaser article_teaser = 3;
+    Commercial commercial = 4;
   }
 }
 
-// A non-recursive collection of teaserable items.
+// A non-recursive collection of teaseable items.
 message TeaserStage {
   repeated TeaserStageItem teaser_stage_items = 1;
-  // stage_layout: schlagzeilen
+  // e.g. stage_layout: schlagzeilen
   map<string, string> fields = 2;
 }
 
-// A single teasable item. (has a href and the click leads to an Ad- or PageImpression)
-// idea: ClickableItem, LinkedItem
+// A single teaseable item.
+// alternatives: ClickableItem, LinkedItem, EverythingButAStage
 message TeaserStageItem {
-  StageItemWidth stage_item_width = 1; // todo
-  map<string, string> fields = 2; // todo: do we need this here as well????
+  // for future flags (pada)
+  map<string, string> fields = 1;
   // At most one field will be set at the same time.
   // The delegate of the StageItem can be an editorial article or a Commercial.
   oneof teaser_stage_item_type {
-    ArticleTeaser article_teaser = 3;
-    Commercial commercial = 4;
-    // is still extendable
+    ArticleTeaser article_teaser = 2;
+    Commercial commercial = 3;
   }
 }
 
@@ -111,22 +110,4 @@ message ArticleTeaser {
 message Commercial {
   // advertisement booking ids
   map<string, string> fields = 1;
-}
-
-// Info to render the width of an item, relative to the page grid.
-// These values represent "desktop-first" widths.
-enum StageItemWidth {
-  STAGE_ITEM_WIDTH_UNSPECIFIED = 0;
-  // 100%
-  STAGE_ITEM_WIDTH_FULL = 1;
-  // 75%
-  STAGE_ITEM_WIDTH_THREE_QUARTERS = 2;
-  // 66%
-  STAGE_ITEM_WIDTH_TWO_THIRDS = 3;
-  // 50%
-  STAGE_ITEM_WIDTH_ONE_HALF = 4;
-  // 33%
-  STAGE_ITEM_WIDTH_ONE_THIRD = 5;
-  // 25%
-  STAGE_ITEM_WIDTH_ONE_QUARTER = 6;
 }

--- a/stroeer/page/section/v1/section_page.proto
+++ b/stroeer/page/section/v1/section_page.proto
@@ -69,23 +69,9 @@ message StageItem {
   // At most one field will be set at the same time.
   // The delegate of the StageItem can be another Stage, an editorial article or a Commercial.
   oneof stage_item_type {
-    TeaserStage stage = 3;
+    TeaserStage teaser_stage = 3;
     ArticleTeaser article_teaser = 4;
     Commercial commercial = 5;
-  }
-}
-
-// A single teasable item. (has a href and the click leads to an Ad- or PageImpression)
-// idea: ClickableItem, LinkedItem
-message TeaserStageItem {
-  StageItemWidth stage_item_width = 1;
-  map<string, string> fields = 2; // todo: do we need this here as well????
-  // At most one field will be set at the same time.
-  // The delegate of the StageItem can be an editorial article or a Commercial.
-  oneof stage_item_type {
-    ArticleTeaser article_teaser = 3;
-    Commercial commercial = 4;
-    // is still extendable
   }
 }
 
@@ -96,10 +82,18 @@ message TeaserStage {
   map<string, string> fields = 2;
 }
 
-// Data to render a Commercial as part of a Stage.
-message Commercial {
-  // advertisement booking ids
-  map<string, string> fields = 1;
+// A single teasable item. (has a href and the click leads to an Ad- or PageImpression)
+// idea: ClickableItem, LinkedItem
+message TeaserStageItem {
+  StageItemWidth stage_item_width = 1;
+  map<string, string> fields = 2; // todo: do we need this here as well????
+  // At most one field will be set at the same time.
+  // The delegate of the StageItem can be an editorial article or a Commercial.
+  oneof teaser_stage_item_type {
+    ArticleTeaser article_teaser = 3;
+    Commercial commercial = 4;
+    // is still extendable
+  }
 }
 
 // Bundles the data needed to render a core article as a teaser.
@@ -112,6 +106,12 @@ message ArticleTeaser {
   // * `teaser_variant`: marker to use also a particular variant of the provided `teaser_layout`.
   // If `teaser_layout` entries is missing use layout `default`.
   map<string, string> fields = 2;
+}
+
+// Data to render a Commercial as part of a Stage.
+message Commercial {
+  // advertisement booking ids
+  map<string, string> fields = 1;
 }
 
 // Info to render the width of an item, relative to the page grid.

--- a/stroeer/page/section/v1/section_page.proto
+++ b/stroeer/page/section/v1/section_page.proto
@@ -42,12 +42,16 @@ message Section {
 message Stage {
   StageConfiguration stage_configuration = 1;
   repeated StageItem stage_items = 2;
-  // optional, always render the column with the Title and SubNav from the StageConfiguration
+  // todo: it is currently unlcear how esi companion elements are represented: It could be either as an article or an element.
   repeated StageItem companions = 3;
 }
 
-// Rendering data for a stage, currently only a fields map.
-// Coordinate stage layouts, especially the `stream` layout with UI department.
+// Coordinate stage and companion layouts, especially the `stream` layout with UI department.
+// The stage title is always part of the `references` -- even without `href`.
+//
+// Info: Why is this an extra message?
+// In case we need more custom & specific configuration like:
+// * sponsoring
 message StageConfiguration {
   // * `stage_layout`: represents a visual layout, which may affect teasers, colors, and other styles.
   // If entry `stage_layout` is missing, use layout `stream`.
@@ -66,7 +70,7 @@ message StageItem {
   // Optional flags/hints for customization only for the stage item.
   map<string, string> fields = 1;
   // At most one field will be set at the same time.
-  // The delegate of the StageItem can be another Stage, an editorial article or a Commercial.
+  // The delegate of the StageItem can be another teaser stage, an editorial article or a commercial.
   oneof stage_item_type {
     TeaserStage stage = 2;
     ArticleTeaser article_teaser = 3;
@@ -86,10 +90,10 @@ message TeaserStage {
 // A single teaseable item.
 // alternatives: ClickableItem, LinkedItem, EverythingButAStage
 message TeaserStageItem {
-  // Optional flags/hints for customization only for the stage item.
+  // Optional flags/hints for customization only for the teaser stage item.
   map<string, string> fields = 1;
   // At most one field will be set at the same time.
-  // The delegate of the StageItem can be an editorial article or a Commercial.
+  // The delegate of the item can be an editorial article or a commercial.
   oneof teaser_stage_item_type {
     ArticleTeaser article_teaser = 2;
     Commercial commercial = 3;

--- a/stroeer/page/section/v1/section_page.proto
+++ b/stroeer/page/section/v1/section_page.proto
@@ -40,8 +40,9 @@ message Section {
 
 // A block of teasers - can consist of editorial articles, advertisement and/or stages.
 message Stage {
-  repeated StageItem stage_items = 1;
-  StageConfiguration stage_configuration = 2;
+  StageConfiguration stage_configuration = 1;
+  repeated StageItem stage_items = 2;
+  repeated StageItem companions = 3; // if present do 1/4 + 3/4 width, if not use 4/4 stage_items
 }
 
 // Rendering data for a stage, currently only a fields map.
@@ -50,6 +51,7 @@ message StageConfiguration {
   // * `stage_title`: represents an optional label to be rendered above a Stage, like "CORONAVIRUS".
   // * `stage_layout`: represents a visual layout, which may affect teasers, colors, and other styles.
   // If entry `stage_layout` is missing, use layout `default`.
+  // the stage_layout field can be used to configure full page width commercials (e.g. nativendo, t-online empfiehlt)
   map<string, string> fields = 1;
 
   // All kind of references as part of the stage. Filter reference by
@@ -61,15 +63,23 @@ message StageConfiguration {
 
 // A single generic item of a stage.
 message StageItem {
-  // Width instructions for rendering the single item.
-  StageItemWidth stage_item_width = 1;
   // At most one field will be set at the same time.
   // The delegate of the StageItem can be another Stage, an editorial article or a Commercial.
   oneof stage_item_type {
+    // can we get rid of recursion?
+    // how else to do Schlagzeilen Stage as Companion (needs particular stage_layout)
+    // how else to have a MRect BETWEEN Editorial Teasers
     Stage stage = 2;
     ArticleTeaser article_teaser = 3;
     Commercial commercial = 4;
+    EdgeSiteInclude edge_site_include = 5;
   }
+}
+
+message EdgeSiteInclude {
+  stroeer.core.v1.Reference include_reference = 1;
+  // do we need this?
+  map<string, string> fields = 2;
 }
 
 // Data to render a Commercial as part of a Stage.

--- a/stroeer/page/section/v1/section_page.proto
+++ b/stroeer/page/section/v1/section_page.proto
@@ -40,7 +40,6 @@ message Section {
 
 // A "row" of teasers - can consist of editorial articles, advertisement and/or stages.
 message Stage {
-  // contains stage_title and sub_navs from now on
   StageConfiguration stage_configuration = 1;
   repeated StageItem stage_items = 2;
   // optional, always render the column with the Title and SubNav from the StageConfiguration
@@ -48,10 +47,10 @@ message Stage {
 }
 
 // Rendering data for a stage, currently only a fields map.
-// Coordinate stage layouts, especially the `default` layout with UI department.
+// Coordinate stage layouts, especially the `stream` layout with UI department.
 message StageConfiguration {
   // * `stage_layout`: represents a visual layout, which may affect teasers, colors, and other styles.
-  // If entry `stage_layout` is missing, use layout `default`.
+  // If entry `stage_layout` is missing, use layout `stream`.
   // the stage_layout field can be used to configure full page width commercials (e.g. nativendo, t-online empfiehlt)
   map<string, string> fields = 1;
 
@@ -64,7 +63,8 @@ message StageConfiguration {
 
 // A single generic item of a stage.
 message StageItem {
-  map<string, string> fields = 1; // for custom flags like bg_color
+  // Optional flags/hints for customization only for the stage item.
+  map<string, string> fields = 1;
   // At most one field will be set at the same time.
   // The delegate of the StageItem can be another Stage, an editorial article or a Commercial.
   oneof stage_item_type {
@@ -76,15 +76,17 @@ message StageItem {
 
 // A non-recursive collection of teaseable items.
 message TeaserStage {
-  repeated TeaserStageItem teaser_stage_items = 1;
-  // e.g. stage_layout: schlagzeilen
-  map<string, string> fields = 2;
+  // * `stage_layout`: represents a visual layout, which may affect teasers, colors, and other styles.
+  // If entry `stage_layout` is missing, use layout `stream`.
+  // the stage_layout field can be used to configure full page width commercials (e.g. nativendo, t-online empfiehlt)
+  map<string, string> fields = 1;
+  repeated TeaserStageItem teaser_stage_items = 2;
 }
 
 // A single teaseable item.
 // alternatives: ClickableItem, LinkedItem, EverythingButAStage
 message TeaserStageItem {
-  // for future flags (pada)
+  // Optional flags/hints for customization only for the stage item.
   map<string, string> fields = 1;
   // At most one field will be set at the same time.
   // The delegate of the StageItem can be an editorial article or a Commercial.
@@ -94,20 +96,20 @@ message TeaserStageItem {
   }
 }
 
-// Bundles the data needed to render a core article as a teaser.
-// Coordinate teaser layouts, especially the `default` layout with UI department.
+// Bundles the data needed to render a core article as a teaser as part of a stage.
+// Coordinate teaser layouts, especially the `stream` layout with UI department.
 message ArticleTeaser {
-  // `Article.body` is set to `null` to reduce overhead.
-  stroeer.core.v1.Article article = 1;
   // `fields` may contain additional rendering information.
   // * `teaser_layout`: marker to use a particular layout in the rendering teaser template.
   // * `teaser_variant`: marker to use also a particular variant of the provided `teaser_layout`.
-  // If `teaser_layout` entries is missing use layout `default`.
+  // If `teaser_layout` entries is missing use layout `stream`.
   map<string, string> fields = 2;
+  // `Article.body` is set to `null` to reduce overhead.
+  stroeer.core.v1.Article article = 1;
 }
 
-// Data to render a Commercial as part of a Stage.
+// Bundles the data to render a commercial as part of a stage.
 message Commercial {
-  // advertisement booking ids
+  // Addtional advertisement booking ids. This may individual for each commercial type.
   map<string, string> fields = 1;
 }

--- a/stroeer/page/section/v1/section_page.proto
+++ b/stroeer/page/section/v1/section_page.proto
@@ -42,16 +42,11 @@ message Section {
 message Stage {
   StageConfiguration stage_configuration = 1;
   repeated StageItem stage_items = 2;
-  // todo: it is currently unlcear how esi companion elements are represented: It could be either as an article or an element.
   repeated StageItem companions = 3;
 }
 
-// Coordinate stage and companion layouts, especially the `stream` layout with UI department.
-// The stage title is always part of the `references` -- even without `href`.
-//
-// Info: Why is this an extra message?
-// In case we need more custom & specific configuration like:
-// * sponsoring
+// Stage and companion layouts must be coordinated with UI department, especially the `stream` layout.
+// The stage title is in the `references`, also when not linked.
 message StageConfiguration {
   // * `stage_layout`: represents a visual layout, which may affect teasers, colors, and other styles.
   // If entry `stage_layout` is missing, use layout `stream`.
@@ -65,35 +60,29 @@ message StageConfiguration {
   repeated stroeer.core.v1.Reference references = 2;
 }
 
-// A single generic item of a stage.
+// A generic model to represent what can be part of a stage.
 message StageItem {
-  // Optional flags/hints for customization only for the stage item.
+  // Optional flags/hints for customization independent of the stage_item_type
   map<string, string> fields = 1;
-  // At most one field will be set at the same time.
-  // The delegate of the StageItem can be another teaser stage, an editorial article or a commercial.
   oneof stage_item_type {
-    TeaserStage stage = 2;
+    TeaserStage teaser_stage = 2;
     ArticleTeaser article_teaser = 3;
     Commercial commercial = 4;
+    // todo: it is currently unclear how esi companion elements are represented.
+    // todo: it could either be an artificial ArticleTeaser containing an EsiElement or an core.Element could be allowed as StageItem oneof.
   }
 }
 
-// A non-recursive collection of teaseable items.
+// A non-recursive collection of teaseable items with its configuration, like layout.
 message TeaserStage {
-  // * `stage_layout`: represents a visual layout, which may affect teasers, colors, and other styles.
-  // If entry `stage_layout` is missing, use layout `stream`.
-  // the stage_layout field can be used to configure full page width commercials (e.g. nativendo, t-online empfiehlt)
-  map<string, string> fields = 1;
+  StageConfiguration stage_configuration = 1;
   repeated TeaserStageItem teaser_stage_items = 2;
 }
 
-// A single teaseable item.
-// alternatives: ClickableItem, LinkedItem, EverythingButAStage
+// A single teaseable item, which can't be a stage.
 message TeaserStageItem {
-  // Optional flags/hints for customization only for the teaser stage item.
+  // Optional flags/hints for customization independent of the teaser_stage_item_type
   map<string, string> fields = 1;
-  // At most one field will be set at the same time.
-  // The delegate of the item can be an editorial article or a commercial.
   oneof teaser_stage_item_type {
     ArticleTeaser article_teaser = 2;
     Commercial commercial = 3;
@@ -114,6 +103,6 @@ message ArticleTeaser {
 
 // Bundles the data to render a commercial as part of a stage.
 message Commercial {
-  // Addtional advertisement booking ids. This may individual for each commercial type.
+  // e.g. advertisement booking ids. Data may differ between commercial types.
   map<string, string> fields = 1;
 }

--- a/stroeer/page/section/v1/section_page.proto
+++ b/stroeer/page/section/v1/section_page.proto
@@ -64,7 +64,6 @@ message StageConfiguration {
 
 // A single generic item of a stage.
 message StageItem {
-  StageItemWidth stage_item_width = 1;
   map<string, string> fields = 2; // "padding-off=true", for commercials, you know
   // At most one field will be set at the same time.
   // The delegate of the StageItem can be another Stage, an editorial article or a Commercial.
@@ -85,7 +84,7 @@ message TeaserStage {
 // A single teasable item. (has a href and the click leads to an Ad- or PageImpression)
 // idea: ClickableItem, LinkedItem
 message TeaserStageItem {
-  StageItemWidth stage_item_width = 1;
+  StageItemWidth stage_item_width = 1; // todo
   map<string, string> fields = 2; // todo: do we need this here as well????
   // At most one field will be set at the same time.
   // The delegate of the StageItem can be an editorial article or a Commercial.

--- a/stroeer/page/section/v1/section_page.proto
+++ b/stroeer/page/section/v1/section_page.proto
@@ -40,6 +40,7 @@ message Section {
 
 // A block of teasers - can consist of editorial articles, advertisement and/or stages.
 message Stage {
+  // contains stage_title from now on
   StageConfiguration stage_configuration = 1;
   repeated StageItem stage_items = 2;
   repeated StageItem companions = 3; // if present do 1/4 + 3/4 width, if not use 4/4 stage_items
@@ -63,28 +64,41 @@ message StageConfiguration {
 
 // A single generic item of a stage.
 message StageItem {
+  StageItemWidth stage_item_width = 1;
+  map<string, string> fields = 2; // "padding-off=true", for commercials, you know
   // At most one field will be set at the same time.
   // The delegate of the StageItem can be another Stage, an editorial article or a Commercial.
   oneof stage_item_type {
-    // can we get rid of recursion?
-    // how else to do Schlagzeilen Stage as Companion (needs particular stage_layout)
-    // how else to have a MRect BETWEEN Editorial Teasers
-    Stage stage = 2;
-    ArticleTeaser article_teaser = 3;
-    Commercial commercial = 4;
-    EdgeSiteInclude edge_site_include = 5;
+    TeaserStage stage = 3;
+    ArticleTeaser article_teaser = 4;
+    Commercial commercial = 5;
   }
 }
 
-message EdgeSiteInclude {
-  stroeer.core.v1.Reference include_reference = 1;
-  // do we need this?
+// A single teasable item. (has a href and the click leads to an Ad- or PageImpression)
+// idea: ClickableItem, LinkedItem
+message TeaserStageItem {
+  StageItemWidth stage_item_width = 1;
+  map<string, string> fields = 2; // todo: do we need this here as well????
+  // At most one field will be set at the same time.
+  // The delegate of the StageItem can be an editorial article or a Commercial.
+  oneof stage_item_type {
+    ArticleTeaser article_teaser = 3;
+    Commercial commercial = 4;
+    // is still extendable
+  }
+}
+
+// A non-recursive collection of teaserable items.
+message TeaserStage {
+  repeated TeaserStageItem teaser_stage_items = 1;
+  // stage_layout: schlagzeilen
   map<string, string> fields = 2;
 }
 
 // Data to render a Commercial as part of a Stage.
-// todo: requirements for this feature are currently missing.
 message Commercial {
+  // advertisement booking ids
   map<string, string> fields = 1;
 }
 

--- a/stroeer/page/section/v1/section_page_service.proto
+++ b/stroeer/page/section/v1/section_page_service.proto
@@ -62,7 +62,7 @@ service SectionPageService {
     HTTP status: 504
     cacheable: no
 
-    **Scenarios about incomplete section data needs to be defined**
+    Scenarios about incomplete section data needs to be defined
    */
   rpc GetSectionPage (GetSectionPageRequest) returns (GetSectionPageResponse) {}
 }


### PR DESCRIPTION
These changes represents the current state of our section ui. Some notable changes:

- no recursive stages anymore. only two level stages.
- explicit companion items
- no explicit width for stage items. handled via stage_layout

The docs are wip.