### PR TITLE
[Proposal] Add page configuration to pages

### DIFF
--- a/stroeer/page/article/v1/article_page.proto
+++ b/stroeer/page/article/v1/article_page.proto
@@ -4,6 +4,7 @@ package stroeer.page.article.v1;
 
 import "stroeer/core/v1/article.proto";
 import "stroeer/page/stage/v1/stage.proto";
+import "stroeer/page/configuration/v1/page_configuration.proto";
 
 option go_package = "github.com/stroeer/go-tapir/page/article/v1;article";
 option java_multiple_files = true;
@@ -22,6 +23,9 @@ message ArticlePage {
 
   // stage(s) for the bottom of article pages, mostly seo cases like A-Z Modules
   repeated stroeer.page.stage.v1.Stage stages = 3;
+
+  // Page configuration from the backend to control logic in the templates
+  stroeer.page.configuration.v1.PageConfiguration page_configuration = 4;
 }
 
 // An editorial article, which is related to another article.

--- a/stroeer/page/configuration/v1/page_configuration.proto
+++ b/stroeer/page/configuration/v1/page_configuration.proto
@@ -1,0 +1,30 @@
+syntax = "proto3";
+
+package stroeer.page.configuration.v1;
+
+option go_package = "github.com/stroeer/go-tapir/page/configuration/v1;article";
+option java_multiple_files = true;
+option java_package = "de.stroeer.page.configuration.v1";
+
+// Page configuration from the backend to control logic in the templates
+message PageConfiguration {
+
+  // all page configuration regarding advertisement
+  message Advertisement {
+
+    // AdUnit values for loading ad scripts
+    message AdUnit {
+      // examples: "homepage", "sport", "gesundheit"
+      string one = 1;
+
+      // e.g. "sport_fussball_1bundesliga" or "sport_mehr-sport_DUMMY"
+      string two = 2;
+    }
+
+    // configuration for the taboola page integration
+    message Taboola {
+      // enable oder disable the rendering of the taboola widget on the page
+      bool enabled = 1;
+    }
+  }
+}

--- a/stroeer/page/configuration/v1/page_configuration.proto
+++ b/stroeer/page/configuration/v1/page_configuration.proto
@@ -8,23 +8,9 @@ option java_package = "de.stroeer.page.configuration.v1";
 
 // Page configuration from the backend to control logic in the templates
 message PageConfiguration {
-
+  Advertisement advertisement = 1;
   // all page configuration regarding advertisement
   message Advertisement {
-
-    // AdUnit values for loading ad scripts
-    message AdUnit {
-      // examples: "homepage", "sport", "gesundheit"
-      string one = 1;
-
-      // e.g. "sport_fussball_1bundesliga" or "sport_mehr-sport_DUMMY"
-      string two = 2;
-    }
-
-    // configuration for the taboola page integration
-    message Taboola {
-      // enable oder disable the rendering of the taboola widget on the page
-      bool enabled = 1;
-    }
+    map<string, string> fields = 1;
   }
 }

--- a/stroeer/page/section/v1/section_page.proto
+++ b/stroeer/page/section/v1/section_page.proto
@@ -4,6 +4,7 @@ package stroeer.page.section.v1;
 
 import "stroeer/core/v1/shared.proto";
 import "stroeer/page/stage/v1/stage.proto";
+import "stroeer/page/configuration/v1/page_configuration.proto";
 
 option go_package = "github.com/stroeer/go-tapir/page/section/v1;section";
 option java_multiple_files = true;
@@ -13,6 +14,9 @@ option java_package = "de.stroeer.page.section.v1";
 message SectionPage {
   Section section = 1;
   repeated stroeer.page.stage.v1.Stage stages = 2;
+
+  // Page configuration from the backend to control logic in the templates
+  stroeer.page.configuration.v1.PageConfiguration page_configuration = 3;
 
   // All meta information to render a section page.
   message Section {


### PR DESCRIPTION
# WHAT
Add a ne message `PageConfiguration` and add it to our current Pages `ArticlePage` and `SectionPage`

# WHY
we need to transport some configuration values from the backend to be usesd in the frontend templates

some of the usecases are:
- pre calculated adunits (we need a file containing hardcoded section mappings that are expected on SDI side)
- taboola on/off per page (usecase: Umfeldvermarktung)
- maybe some switchboard features like turning off some 3rd party integration