### PR TITLE
feat(api): remove amp

### DIFF
--- a/stroeer/core/v1/article.proto
+++ b/stroeer/core/v1/article.proto
@@ -92,7 +92,6 @@ this map will contain the following data:
 | `top_line`             | *         | "dachzeile"                                                                                       |
 | `ref_path`             | *         | URL path for this article e.g. `/${section_tree}/id_${id}/${title}.html`                          |
 | `ref_canonical`        | *         | Canonical URL of this article, may differ if external, e.g. https://www.example.com/external.html |
-| `ref_amp`              | *         | AMP URL of this article                                                                           |
 | `summary`              |           | summary for this content                                                                          |
 | `teaser_text`          |           | used on teasers, overrides `summary`                                                              |
 | `meta_robots`          |           |                                                                                                   |
@@ -465,7 +464,6 @@ For details on certain `fields` or usages of [`Assets`, please follow this link.
 *         "headline": "Gallery ipsum dolor",
 *         "ref_path": "/test-playground/id_100000067/gallery-ipsum-dolor.html",
 *         "ref_canonical": "https://www.t-online.de/test-playground/id_100000067/gallery-ipsum-dolor.html",
-*         "ref_amp": "https://www.t-online.de/amp/test-playground/id_100000067/gallery-ipsum-dolor.html",
 *         "url": "/test-playground/id_100000067/gallery-ipsum-dolor.html"
 *       }
 *     }

--- a/stroeer/page/section/v1/section_page.proto
+++ b/stroeer/page/section/v1/section_page.proto
@@ -26,7 +26,6 @@ message SectionPage {
     //
     // * `ref_path`: URL path for this section e.g. /section/id_$ID/title.html
     // * `ref_canonical`: Canonical URL of this section, may differ if external, e.g. https://www.giga.de/tech/
-    // * `ref_amp`: AMP URL of this section
     //
     // Clients must be resilient to unknown or missing entry sets.
     map<string, string> fields = 1;


### PR DESCRIPTION
It is still not clear if we need to support AMP. Paper already removed the `ref_amp` properties completely. This might be a breaking change, because `ref_amp` is mandatory.

Affected services:

- [x] [paper](https://github.com/stroeer/paper/pull/1371)
- [ ] adapter

Needs to refresh the whole content: :x:
