### PR TITLE
feat(api): rename BodyNode.img to BodyNode.image

### DIFF
--- a/stroeer/core/v1/article.proto
+++ b/stroeer/core/v1/article.proto
@@ -807,7 +807,7 @@ Clients must be resilient to unknown or missing nodes.
 
 | type            | description                                                                   |
 |-----------------|-------------------------------------------------------------------------------|
-| `img`           | inline image element, check `elements`                                        |
+| `image`         | inline image element, check `elements`                                        |
 | `video`         | inline video element, check `elements`                                        |
 | `gallery`       | inline gallery element, check `elements`                                      |
 | `oembed`        | inline oEmbed element, check `elements`                                       |


### PR DESCRIPTION
This is the only inconsistency of our naming (related to elements).

Affected services:

- [x] paper ([PR](https://github.com/stroeer/paper/pull/1483): paper supports both namings)
- [ ] adapter

Needs to refresh the whole content: :white_check_mark: