### PR TITLE
feat: add RelatedArticle source as string

### DIFF
--- a/stroeer/page/article/v1/article_page.proto
+++ b/stroeer/page/article/v1/article_page.proto
@@ -44,9 +44,17 @@ message RelatedArticle {
   // thus not containing any data that is only required on detail pages).
   stroeer.core.v1.Article article = 1;
 
-  // Deprecated source of the related article in form of an enum.
-  reserved 2;
+  // Deprecated (since 04.04.2023) source of the related article in form of an enum.
+  RelatedArticleSource source = 2;
 
   // Source of the related article.
-  string source = 3;
+  string related_article_source = 3;
+}
+
+enum RelatedArticleSource {
+  // Not specified.
+  RELATED_ARTICLE_SOURCE_UNSPECIFIED = 0;
+
+  // Article was related manually by the editorial department.
+  RELATED_ARTICLE_SOURCE_EDITORIAL = 1;
 }

--- a/stroeer/page/article/v1/article_page.proto
+++ b/stroeer/page/article/v1/article_page.proto
@@ -44,15 +44,9 @@ message RelatedArticle {
   // thus not containing any data that is only required on detail pages).
   stroeer.core.v1.Article article = 1;
 
+  // Deprecated source of the related article in form of an enum.
+  reserved 2;
+
   // Source of the related article.
-  RelatedArticleSource source = 2;
-}
-
-// Source of the related article.
-enum RelatedArticleSource {
-  // Not specified.
-  RELATED_ARTICLE_SOURCE_UNSPECIFIED = 0;
-
-  // Article was related manually by the editorial department.
-  RELATED_ARTICLE_SOURCE_EDITORIAL = 1;
+  string source = 3;
 }


### PR DESCRIPTION
### WHAT
RelatedArticle: replace field `source` of type enum with field `related_article_source` of type string

### WHY
https://t-online.atlassian.net/browse/BUZZ-3688
https://t-online.atlassian.net/browse/BUZZ-3700