### PR TITLE
feat: buf bsr

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -121,3 +121,15 @@ jobs:
           -H 'Accept: application/vnd.github.everest-preview+json' \
           -u ${{ secrets.GO_TAPIR_TOKEN }} \
           --data '{"event_type": "publish", "client_payload": { "tag": "'"$RELEASE_TAG"'" }}'
+
+  buf:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: bufbuild/buf-setup-action@v1
+
+      - uses: bufbuild/buf-push-action@v1
+        with:
+          buf_token: ${{ secrets.BUF_TOKEN }}
+          draft: ${{ github.ref_name != 'main'}}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -91,7 +91,7 @@ jobs:
       - name: generate go code
         run: make generate TEMPLATE=buf.gen.go.yaml
 
-  lint:
+  buf:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -100,15 +100,13 @@ jobs:
 
       - uses: bufbuild/buf-lint-action@v1
 
-  breaking:
-      runs-on: ubuntu-latest
-      steps:
-        - uses: actions/checkout@v3
+      - uses: bufbuild/buf-breaking-action@v1
+        if: always()
+        with:
+          against: "https://github.com/stroeer/tapir.git#branch=main"
 
-        - uses: bufbuild/buf-setup-action@v1
-
-        - uses: bufbuild/buf-breaking-action@v1
-          if: always()
-          with:
-            against: "https://github.com/stroeer/tapir.git#branch=main"
+      - uses: bufbuild/buf-push-action@v1
+        with:
+          buf_token: ${{ secrets.BUF_TOKEN }}
+          draft: ${{ github.ref_name != 'main'}}
 

--- a/stroeer/navigation/v1/navigation_service.proto
+++ b/stroeer/navigation/v1/navigation_service.proto
@@ -6,21 +6,25 @@ import "stroeer/core/v1/shared.proto";
 
 option go_package = "github.com/stroeer/go-tapir/navigation/v1;navigation";
 
+// The navigation service provides access to the navigation tree structure
+// used in t-online products
 service NavigationService {
-  // Retrieve navigation tree structure
+  // Get navigation tree structure for t-online products
   rpc GetNavigation(GetNavigationRequest) returns (GetNavigationResponse) {}
 }
 
+// Request for getting navigation tree structure
 message GetNavigationRequest {}
 
+//Response for getting navigation tree structure
 message GetNavigationResponse {
   // Navigation tree structure including internal and external references
-  // The root references has nested references
+  // The root reference has nested references
   // root
-  //   - menu
-  //     - submenu
-  //   - menu
-  //     - submenu
-  //     - external references
+  //  - menu
+  //    - submenu
+  //  - menu
+  //    - submenu
+  //    - external references
   stroeer.core.v1.Reference navigation_menu = 1;
 }


### PR DESCRIPTION
## what

PoC to test buf's maven remote packages (see https://buf.build/docs/bsr/remote-packages/maven/). 

see https://buf.build/stroeer/tapir/assets/main for assets

## learnings

✅ buf's remote packages are separated for proto and grpc per default
✅ packages build for various proto and grpc versions are available
✅ we could remove the java package release process in tapir and simplify our tools
✅ tested in a gRPC go project: https://github.com/stroeer/go-tapir/pull/35
✅ registries for TypeScript, python and Swift are available as well (not tested in this poc)
✅ automatic documentation is nice and we could simplify our docs toolchain, see https://buf.build/stroeer/tapir/docs/main

🟡  we can't specifiy custom tag values for default `buf push` GitHub action (we could create a custom make target though)
🟡 might be free (see [plans](https://buf.build/pricing)), according to ` buf beta price` it would cost $34.00/month for Teams plan which doesn't add much value
🟡 buf is a startup and might run out of money

❌ packages names are different (see large diff in https://github.com/stroeer/paperboy/pull/1984) and can't be changed easily atm, see https://github.com/bufbuild/plugins/issues/636

## outcome

- I would push to the BSR at least to use the documentation
- using remote SDKs could be a huge simplification of out tool chain