### PR TITLE
update required npm version for node-proto

### DIFF
--- a/node-proto/package-lock.json
+++ b/node-proto/package-lock.json
@@ -21,7 +21,7 @@
       },
       "engines": {
         "node": "18",
-        "npm": "9"
+        "npm": ">=9"
       }
     },
     "node_modules/@bufbuild/protobuf": {

--- a/node-proto/package.json
+++ b/node-proto/package.json
@@ -5,7 +5,7 @@
   "type": "commonjs",
   "engines": {
     "node": "18",
-    "npm": "9"
+    "npm": ">=9"
   },
   "scripts": {
     "build": "tsc -b",


### PR DESCRIPTION
what
set a required minimum npm version for node-proto instead of fixed version 9.
Node 18 LTS now ships with npm 10.
I assume it is unlikely that new node/npm versions will break functionality.

outcome
When updating node/npm the package won't fail to install.
Right now it blocks our pipeline to build our application.
![image](https://github.com/stroeer/tapir/assets/62701806/9f085212-4ae4-4fd8-8d82-df942d224755)
