### PR TITLE
feat: push tapir to Buf schema registry for each new tag

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -138,4 +138,4 @@ jobs:
         run: |
           RELEASE_TAG=${GITHUB_REF/refs\/tags\/v/}
           echo $RELEASE_TAG
-          make push LABEL=RELEASE_TAG
+          make push

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -121,3 +121,21 @@ jobs:
           -H 'Accept: application/vnd.github.everest-preview+json' \
           -u ${{ secrets.GO_TAPIR_TOKEN }} \
           --data '{"event_type": "publish", "client_payload": { "tag": "'"$RELEASE_TAG"'" }}'
+
+
+  bsr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: bufbuild/buf-setup-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: push
+        env:
+          BUF_TOKEN: ${{ secrets.BUF_TOKEN }}
+        run: |
+          RELEASE_TAG=${GITHUB_REF/refs\/tags\/v/}
+          echo $RELEASE_TAG
+          make push LABEL=RELEASE_TAG

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -97,6 +97,8 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: bufbuild/buf-setup-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: bufbuild/buf-lint-action@v1
 
@@ -106,6 +108,8 @@ jobs:
         - uses: actions/checkout@v4
 
         - uses: bufbuild/buf-setup-action@v1
+          with:
+            github_token: ${{ secrets.GITHUB_TOKEN }}
 
         - uses: bufbuild/buf-breaking-action@v1
           if: always()

--- a/Makefile
+++ b/Makefile
@@ -26,16 +26,11 @@ build: ## Builds buf image, see https://buf.build/docs/reference/images
 	@echo "+ $@"
 	@buf build
 
-# Buf bsr label, see https://buf.build/docs/bsr/module/publish#pushing-with-labels
 LABEL ?=
 .PHONY: push
-push: build ## Pushes tapir to the buf schema registry, see https://buf.build/docs/bsr/introduction
+push: build ## Pushes tapir to the buf schema registry, see https://buf.build/docs/bsr/introduction and https://buf.build/docs/bsr/module/publish#pushing-with-labels
 	@echo "+ $@"
-ifeq ($(LABEL),)
-	@buf push
-else
-	@buf push --label $(LABEL)
-endif
+	@buf push --git-metadata
 
 .PHONY: test
 test: generate ## Runs all tests

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: generate test fmt lint breaking
+all: build generate test fmt lint breaking
 
 TEMPLATE ?= buf.gen.yaml
 .PHONY: generate
@@ -20,6 +20,22 @@ breaking: ## Detects breaking changes using https://docs.buf.build/breaking-over
 fmt: ## Formats all proto files using https://docs.buf.build/format/style
 	@echo "+ $@"
 	@buf format -w
+
+.PHONY: build
+build: ## Builds buf image, see https://buf.build/docs/reference/images
+	@echo "+ $@"
+	@buf build
+
+# Buf bsr label, see https://buf.build/docs/bsr/module/publish#pushing-with-labels
+LABEL ?=
+.PHONY: push
+push: build ## Pushes tapir to the buf schema registry, see https://buf.build/docs/bsr/introduction
+	@echo "+ $@"
+ifeq ($(LABEL),)
+	@buf push
+else
+	@buf push --label $(LABEL)
+endif
 
 .PHONY: test
 test: generate ## Runs all tests


### PR DESCRIPTION
## what

Push tapir on release to the (public) [buf schema registry](https://buf.build/stroeer/tapir) of tapir.

## why

see https://buf.build/docs/bsr/introduction#bsr-goals for details

✅ automatic documentation, we could remove duplications for funcdoc and simplify tools, see https://buf.build/stroeer/tapir
✅ automatic generation of client SDKs for various proto/grpc versions and languages like java, TypeScript, Go, Swift and Python - we could remove our tooling around packaging and hosting SDKs

🟡 might be free (see [plans](https://buf.build/pricing)), according to ` buf beta price` it would cost $34.00/month for Teams plan which doesn't add much value
🟡 we would need to refactor our imports in the client projects to the buf naming conventions, see examples for [java](https://github.com/stroeer/paperboy/pull/1984) and [go](https://github.com/stroeer/go-tapir/pull/35)