### PR TITLE
feat: article extender question/answer models + service

### DIFF
--- a/stroeer/core/v1/article.proto
+++ b/stroeer/core/v1/article.proto
@@ -681,14 +681,14 @@ message Article {
      * Each `Body` has a `Body.Type` to help the consumer to correctly interpret
      * the  [`BodyNode's`][bn] content.
      *
-     * | Enum value          | Description                                                                                                               |
-     * |---------------------|---------------------------------------------------------------------------------------------------------------------------|
-     * | `TYPE_UNSPECIFIED`  | unspecified                                                                                                               |
-     * | `BODY`              | The textual article body including all inline elements such as `IMAGE`, `VIDEO` and `EMBED`                               |
-     * | `ARTICLE_SOURCES`   | A wrapper for all article sources ("Quellenaparat"). There can only be one of these per article.                          |
-     * | `DISCLAIMER`        | A article disclaimer with important notes/legal stuff. E.g. "medizinischer Hinweis" on all medical articles               |
-     * | `TRUST_BOX`         | Includes information what the current article type is (e.g. opinion article). There can only be one of these per article. |
-     * | `TABLE_OF_CONTENTS` | Table of contents for this article, consists of anchors which refer to sub headlines within the `BODY`                    |
+     * | Enum value          | Description                                                                                                 |
+     * |---------------------|-------------------------------------------------------------------------------------------------------------|
+     * | `TYPE_UNSPECIFIED`  | unspecified                                                                                                 |
+     * | `BODY`              | The textual article body including all inline elements such as `IMAGE`, `VIDEO` and `EMBED`                 |
+     * | `ARTICLE_SOURCES`   | A wrapper for all article sources ("Quellenaparat"). There can only be one of these per article.            |
+     * | `DISCLAIMER`        | A article disclaimer with important notes/legal stuff. E.g. "medizinischer Hinweis" on all medical articles |
+     * | `TABLE_OF_CONTENTS` | Table of contents for this article, consists of anchors which refer to sub headlines within the `BODY`      |
+     * | `ARTICLE_EXTENDER`  | AI generated questions for the article for more engagement.                                                 |
      *
      * @CodeBlockStart protobuf
      */
@@ -697,8 +697,9 @@ message Article {
       BODY = 1;
       ARTICLE_SOURCES = 2;
       DISCLAIMER = 3;
-      TRUST_BOX = 4;
+      TRUST_BOX = 4 [deprecated = true];
       TABLE_OF_CONTENTS = 5;
+      ARTICLE_EXTENDER = 6;
     }
     /** @CodeBlockEnd */
 

--- a/stroeer/core/v1/article.proto
+++ b/stroeer/core/v1/article.proto
@@ -780,7 +780,7 @@ message Article {
      * | `quote`         | inline quotation element, check `elements`                                    |
      * | `infobox`       | inline box, consists of textual content in `children` and optional `elements` |
      * | `pros_and_cons` | pros and cons box, consists of `elements` and structured text in `children`   |
-     *
+     * | `question`      | article extender: ai generated question                                       |
      */
   }
 

--- a/stroeer/page/article/v1/article_extender_service.proto
+++ b/stroeer/page/article/v1/article_extender_service.proto
@@ -5,6 +5,8 @@ syntax = "proto3";
 
 package stroeer.page.article.v1;
 
+import "stroeer/core/v1/article.proto";
+
 option go_package = "github.com/stroeer/go-tapir/page/article/v1;article";
 
 /**
@@ -15,6 +17,7 @@ option go_package = "github.com/stroeer/go-tapir/page/article/v1;article";
  */
 service ArticleExtenderService {
   rpc GetQuestions(GetQuestionsRequest) returns (GetQuestionsResponse) {}
+  rpc GetAnswer(GetAnswerRequest) returns (GetAnswerResponse) {}
 }
 /** @CodeBlockEnd */
 
@@ -24,7 +27,7 @@ service ArticleExtenderService {
  * rpc GetQuestions(GetQuestionsRequest) returns (GetQuestionsResponse) {}
  * ```
  *
- * returns an array of questions if the given `id` exists, in the vector store,
+ * Returns an array of questions if the given `id` exists, in the vector store,
  * an `Error`, otherwise.
  *
  * | Field name       | Type                | Description                                                           |
@@ -33,11 +36,34 @@ service ArticleExtenderService {
  *
  * @CodeBlockStart protobuf
  */
-
 message GetQuestionsRequest {
   int64 id = 1;
 }
 
 message GetQuestionsResponse {
   repeated string questions = 1;
+}
+
+/**
+ * # `⚙︎ GetAnswer`
+ * ```protobuf
+ * rpc GetAnswer(GetAnswerRequest) returns (GetAnswerResponse) {}
+ * ```
+ *
+ * Returns the answer of a question as a string. Otherwise an `Error`.
+ *
+ * | Field name       | Type                | Description                                       |
+ * |------------------|---------------------|---------------------------------------------------|
+ * | `question`       | `string`            | [required] The question for the returned answers. |
+ *
+ * @CodeBlockStart protobuf
+ */
+message GetAnswerRequest {
+  string question = 1;
+}
+
+message GetAnswerResponse {
+  string answer_text = 1;
+  repeated stroeer.core.v1.Article answer_sources = 2;
+  repeated string next_questions = 3;
 }

--- a/stroeer/page/article/v1/article_extender_service.proto
+++ b/stroeer/page/article/v1/article_extender_service.proto
@@ -63,7 +63,7 @@ message GetAnswerRequest {
 }
 
 message GetAnswerResponse {
-  string answer_text = 1;
-  repeated stroeer.core.v1.Article answer_sources = 2;
-  repeated string next_questions = 3;
+  string answer = 1;
+  repeated stroeer.core.v1.Article sources = 2;
+  repeated string further_questions = 3;
 }


### PR DESCRIPTION
## What

- added a new `Body` type `ARTICLE_EXTENDER`
- `BodyNode` type is just a `string` -- using `question` for filtering
- add new `ArticleExtenderServer` method/function to receive answers for a question
- deprecated `TRUST_BOX` (already deleted in cms, adapter, frontend)

## Example `Body` with initial questions

```json
{
  "children": [
    {
      "children": [],
      "elements": [],
      "fields": {},
      "type": "question",
      "text": "Was hilft gegen Ungeziefer im Garten?",
      "reference": null
    },
  ],
  "type": "ARTICLE_EXTENDER"
}
```