### PR TITLE
feat: add original article id to article_extender_service.proto

### DIFF
--- a/stroeer/page/article/v1/article_extender_service.proto
+++ b/stroeer/page/article/v1/article_extender_service.proto
@@ -61,7 +61,7 @@ message GetQuestionsResponse {
  */
 message GetAnswerRequest {
   string question = 1;
-  int64 article_id = 1;
+  int64 article_id = 2;
 }
 
 message GetAnswerResponse {

--- a/stroeer/page/article/v1/article_extender_service.proto
+++ b/stroeer/page/article/v1/article_extender_service.proto
@@ -55,11 +55,13 @@ message GetQuestionsResponse {
  * | Field name       | Type                | Description                                       |
  * |------------------|---------------------|---------------------------------------------------|
  * | `question`       | `string`            | [required] The question for the returned answers. |
+ * | `article_id`     | `int64`             | [required] The original article the user read.
  *
  * @CodeBlockStart protobuf
  */
 message GetAnswerRequest {
   string question = 1;
+  int64 article_id = 1;
 }
 
 message GetAnswerResponse {

--- a/stroeer/page/article/v1/article_extender_service.proto
+++ b/stroeer/page/article/v1/article_extender_service.proto
@@ -55,7 +55,7 @@ message GetQuestionsResponse {
  * | Field name       | Type                | Description                                       |
  * |------------------|---------------------|---------------------------------------------------|
  * | `question`       | `string`            | [required] The question for the returned answers. |
- * | `article_id`     | `int64`             | [required] The original article the user read.
+ * | `article_id`     | `int64`             | [required] The original article the user read.    |
  *
  * @CodeBlockStart protobuf
  */


### PR DESCRIPTION
we need the article id, so that the LLM answer does not include the current article