### PR TITLE
feat: add fields `question_source` and `accept` to GetAnswerRequest

### DIFF
--- a/stroeer/page/article/v1/article_extender_service.proto
+++ b/stroeer/page/article/v1/article_extender_service.proto
@@ -64,6 +64,49 @@ message GetAnswerRequest {
   int64 article_id = 2;
   QuestionSource question_source = 3;
   Accept accept = 4;
+
+  /** @CodeBlockEnd */
+
+  /**
+   * ## `enum QuestionSource`
+   * Information about the source of the question.
+   * User questions must be treated differently than questions that we provided.
+   *
+   * | Enum value                    | Description                                                  |
+   * |-------------------------------|--------------------------------------------------------------|
+   * | `QUESTION_SOURCE_UNSPECIFIED` | unspecified                                                  |
+   * | `INITIAL_QUESTIONS`           | The question was part of the initial server-side response.   |
+   * | `USER`                        | The question is an input from the user.                      |
+   *
+   *
+   * @CodeBlockStart protobuf
+   */
+  enum QuestionSource {
+    QUESTION_SOURCE_UNSPECIFIED = 0;
+    INITIAL_QUESTIONS = 1;
+    USER = 2;
+  }
+
+  /** @CodeBlockEnd */
+
+  /**
+   * ## `enum Accept`
+   * The client can specify the format of the answer text.
+   *
+   * | Enum value            | Description                                                  |
+   * |-----------------------|--------------------------------------------------------------|
+   * | `ACCEPT_UNSPECIFIED`  | unspecified                                                  |
+   * | `PLAINTEXT`           | The question was part of the initial server-side response.   |
+   * | `MARKDOWN`            | The question is an input from the user.                      |
+   *
+   *
+   * @CodeBlockStart protobuf
+   */
+  enum Accept {
+    ACCEPT_UNSPECIFIED = 0;
+    PLAINTEXT = 1;
+    MARKDOWN = 2;
+  }
 }
 
 message GetAnswerResponse {
@@ -71,47 +114,4 @@ message GetAnswerResponse {
   repeated stroeer.core.v1.Article sources = 2 [deprecated = true];
   repeated string further_questions = 3;
   repeated int64 source_ids = 4;
-}
-
-/** @CodeBlockEnd */
-
-/**
- * ## `enum QuestionSource`
- * Information about the source of the question.
- * User questions must be treated differently than questions that we provided.
- *
- * | Enum value                    | Description                                                  |
- * |-------------------------------|--------------------------------------------------------------|
- * | `QUESTION_SOURCE_UNSPECIFIED` | unspecified                                                  |
- * | `INITIAL_QUESTIONS`           | The question was part of the initial server-side response.   |
- * | `USER`                        | The question is an input from the user.                      |
- *
- *
- * @CodeBlockStart protobuf
- */
-enum QuestionSource {
-  QUESTION_SOURCE_UNSPECIFIED = 0;
-  INITIAL_QUESTIONS = 1;
-  USER = 2;
-}
-
-/** @CodeBlockEnd */
-
-/**
- * ## `enum Accept`
- * The client can specify the format of the answer text.
- *
- * | Enum value            | Description                                                  |
- * |-----------------------|--------------------------------------------------------------|
- * | `ACCEPT_UNSPECIFIED`  | unspecified                                                  |
- * | `PLAINTEXT`           | The question was part of the initial server-side response.   |
- * | `MARKDOWN`            | The question is an input from the user.                      |
- *
- *
- * @CodeBlockStart protobuf
- */
-enum Accept {
-  ACCEPT_UNSPECIFIED = 0;
-  PLAINTEXT = 1;
-  MARKDOWN = 2;
 }

--- a/stroeer/page/article/v1/article_extender_service.proto
+++ b/stroeer/page/article/v1/article_extender_service.proto
@@ -76,19 +76,19 @@ message GetAnswerResponse {
 /** @CodeBlockEnd */
 
 /**
-* ## `enum QuestionSource`
-* Information about the source of the question.
-* User questions must be treated differently than questions that we provided.
-*
-* | Enum value                    | Description                                                  |
-* |-------------------------------|--------------------------------------------------------------|
-* | `QUESTION_SOURCE_UNSPECIFIED` | unspecified                                                  |
-* | `INITIAL_QUESTIONS`           | The question was part of the initial server-side response.   |
-* | `USER`                        | The question is an input from the user.                      |
-*
-*
-* @CodeBlockStart protobuf
-*/
+ * ## `enum QuestionSource`
+ * Information about the source of the question.
+ * User questions must be treated differently than questions that we provided.
+ *
+ * | Enum value                    | Description                                                  |
+ * |-------------------------------|--------------------------------------------------------------|
+ * | `QUESTION_SOURCE_UNSPECIFIED` | unspecified                                                  |
+ * | `INITIAL_QUESTIONS`           | The question was part of the initial server-side response.   |
+ * | `USER`                        | The question is an input from the user.                      |
+ *
+ *
+ * @CodeBlockStart protobuf
+ */
 enum QuestionSource {
   QUESTION_SOURCE_UNSPECIFIED = 0;
   INITIAL_QUESTIONS = 1;
@@ -98,18 +98,18 @@ enum QuestionSource {
 /** @CodeBlockEnd */
 
 /**
-* ## `enum Accept`
-* The client can specify the format of the answer text.
-*
-* | Enum value            | Description                                                  |
-* |-----------------------|--------------------------------------------------------------|
-* | `ACCEPT_UNSPECIFIED`  | unspecified                                                  |
-* | `PLAINTEXT`           | The question was part of the initial server-side response.   |
-* | `MARKDOWN`            | The question is an input from the user.                      |
-*
-*
-* @CodeBlockStart protobuf
-*/
+ * ## `enum Accept`
+ * The client can specify the format of the answer text.
+ *
+ * | Enum value            | Description                                                  |
+ * |-----------------------|--------------------------------------------------------------|
+ * | `ACCEPT_UNSPECIFIED`  | unspecified                                                  |
+ * | `PLAINTEXT`           | The question was part of the initial server-side response.   |
+ * | `MARKDOWN`            | The question is an input from the user.                      |
+ *
+ *
+ * @CodeBlockStart protobuf
+ */
 enum Accept {
   ACCEPT_UNSPECIFIED = 0;
   PLAINTEXT = 1;

--- a/stroeer/page/article/v1/article_extender_service.proto
+++ b/stroeer/page/article/v1/article_extender_service.proto
@@ -62,6 +62,8 @@ message GetQuestionsResponse {
 message GetAnswerRequest {
   string question = 1;
   int64 article_id = 2;
+  QuestionSource question_source = 3;
+  Accept accept = 4;
 }
 
 message GetAnswerResponse {
@@ -69,4 +71,47 @@ message GetAnswerResponse {
   repeated stroeer.core.v1.Article sources = 2 [deprecated = true];
   repeated string further_questions = 3;
   repeated int64 source_ids = 4;
+}
+
+/** @CodeBlockEnd */
+
+/**
+* ## `enum QuestionSource`
+* Information about the source of the question.
+* User questions must be treated differently than questions that we provided.
+*
+* | Enum value                    | Description                                                  |
+* |-------------------------------|--------------------------------------------------------------|
+* | `QUESTION_SOURCE_UNSPECIFIED` | unspecified                                                  |
+* | `INITIAL_QUESTIONS`           | The question was part of the initial server-side response.   |
+* | `USER`                        | The question is an input from the user.                      |
+*
+*
+* @CodeBlockStart protobuf
+*/
+enum QuestionSource {
+  QUESTION_SOURCE_UNSPECIFIED = 0;
+  INITIAL_QUESTIONS = 1;
+  USER = 2;
+}
+
+/** @CodeBlockEnd */
+
+/**
+* ## `enum Accept`
+* The client can specify the format of the answer text.
+*
+* | Enum value            | Description                                                  |
+* |-----------------------|--------------------------------------------------------------|
+* | `ACCEPT_UNSPECIFIED`  | unspecified                                                  |
+* | `PLAINTEXT`           | The question was part of the initial server-side response.   |
+* | `MARKDOWN`            | The question is an input from the user.                      |
+*
+*
+* @CodeBlockStart protobuf
+*/
+enum Accept {
+  ACCEPT_UNSPECIFIED = 0;
+  PLAINTEXT = 1;
+  MARKDOWN = 2;
 }


### PR DESCRIPTION
- Add field `question_source` to GetAnswerRequest to be able to treat user questions differently, e.g. with a different prompt (AE-100)
- Add field `accept` to GetAnswerRequest, because we want to add markdown formatting for the answer text (AE-67)