### PR TITLE
feat: added WebVTT as new Asset.Type

### DIFF
--- a/stroeer/core/v1/article.proto
+++ b/stroeer/core/v1/article.proto
@@ -527,11 +527,12 @@ message Article {
        * |--------------------|----------------------------------------------------------------------------------------------------------------------------|
        * | `TYPE_UNSPECIFIED` | unspecified                                                                                                                |
        * | `IMAGE`            | image asset with an resizable template URL and some image stats (`width`, `height`, `cropping`). See [`samples`](#samples) |
-       * | `VIDEO`            | internal video asset, expect (`m3u8`/`HLS`) URLS and some video stats (`width`, `height`, `druation`) within `fields`      |
+       * | `VIDEO`            | internal video asset, expect (`m3u8`/`HLS`) URLS and some video stats (`width`, `height`, `duration`) within `fields`      |
        * | `EXTERNAL_VIDEO`   | holds (`m3u8`/`HLS`) URLS to external videos, such as _live streams_ and _glomex_                                          |
        * | `METADATA`         | holds [`Metadata`][meta] for the parent element and `fields` that also depend on the parent `Element.Type`                 |
        * | `LINK`             | additional link (href, reference) asset for parent `Element`, e.g. an `image` with an optional link target.                |
-       * | `AUDIO`             | internal audio asset, expect (`mp3`) URLS    |
+       * | `AUDIO`            | internal audio asset, expect (`mp3`) URLS                                                                                  |
+       * | `WEB_VTT`          | Web Video Text Tracks, usually used for video subtitles.                                                                   |
        *
        * @CodeBlockStart protobuf
        */
@@ -544,6 +545,7 @@ message Article {
         METADATA = 4;
         LINK = 5;
         AUDIO = 6;
+        WEB_VTT = 7;
       }
       /** @CodeBlockEnd */
     }


### PR DESCRIPTION
~> support one or more WebVTT assets per video element.

```json
{
  "type": "WEB_VTT",
  "fields" : {
    "url": "https://videos.t-online.de/2022/12/E2gC8s1n4W7j/web_vtt/subtitles_de.vtt",
    "lang": "de",
    "label": "Deutsch"
  }
}
```