### PR TITLE
fix(ci): github packages publish permissions

### DIFF
--- a/.github/workflows/proto.yaml
+++ b/.github/workflows/proto.yaml
@@ -30,6 +30,9 @@ jobs:
 
   node:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
 
@@ -72,54 +75,11 @@ jobs:
           npm version $RELEASE_TAG
           npm publish
 
-  node-proto:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          cache: 'npm'
-          cache-dependency-path: 'node-proto/package-lock.json'
-          node-version-file: 'node-proto/.nvmrc'
-          registry-url: "https://npm.pkg.github.com"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: bufbuild/buf-action@v1
-        with:
-          setup_only: true
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          token: ${{ secrets.BUF_TOKEN }}
-
-      - name: install
-        working-directory: node-proto
-        run: npm ci
-
-      - name: generate
-        run: make generate TEMPLATE=buf.gen.node-proto.yaml
-
-      - name: build
-        working-directory: node-proto
-        run: npm run build
-
-      - name: checks
-        working-directory: node-proto
-        run: npm run checks
-
-      - name: publish
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-        working-directory: node-proto
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          RELEASE_TAG=${GITHUB_REF/refs\/tags\/v/}
-          echo $RELEASE_TAG
-          npm version $RELEASE_TAG
-          npm publish
-
   node-buf:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
- removed `node-proto` workflow because it's deprecated
- fixed publish permissions for `node` & `node-buf`